### PR TITLE
Implement hierarchical role privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
-# invisible-hand
-A site for the proposed Invisible Hand market-based happy hour
+# Invisible Hand Arcade
+
+A prototype web application for running a social-hour marketplace with dynamically priced minigames, snack redemptions, and live economic telemetry. The project uses Flask, SQLite, and Google OAuth to manage player balances, merchant tools, and an administrative command center.
+
+## Features
+
+- Google-based authentication for players, merchants, and admins.
+- SQLite-backed models for users, transactions, products, inventory history, and head-to-head games.
+- Single-player clicker prototype that awards credits and logs transactions.
+- Two-player Prisoner's Dilemma matchmaking with automatic payouts based on player choices.
+- Merchant console for creating items, updating prices or stock, and generating QR codes for checkout.
+- Point-of-sale flow that merchants can use to process purchases, decrement stock, and transfer credits.
+- Admin dashboard showing price trends, a live transaction ticker, and role assignment controls.
+
+## Getting Started
+
+### Requirements
+
+- Python 3.10+
+- Google Cloud OAuth 2.0 credentials (web application)
+
+Install dependencies with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv sync
+source .venv/bin/activate
+```
+
+### Configuration
+
+Create an `.env` file or export the following variables before running the app:
+
+```bash
+export FLASK_APP=app.py
+export FLASK_ENV=development
+export SECRET_KEY="change-me"
+export GOOGLE_CLIENT_ID="your-google-client-id"
+export GOOGLE_CLIENT_SECRET="your-google-client-secret"
+```
+
+### Database
+
+Initialize the SQLite database (this will create `instance/app.sqlite`):
+
+```bash
+flask --app app.py init-db
+```
+
+You can use the Flask shell to promote your account to admin or merchant after signing in once:
+
+```bash
+flask --app app.py shell
+>>> from app import db
+>>> from app.models import User, Role
+>>> user = User.query.filter_by(email="you@example.com").first()
+>>> user.role = Role.ADMIN
+>>> db.session.commit()
+```
+
+### Running the App
+
+Start the development server:
+
+```bash
+flask --app app.py run --debug
+```
+
+Visit <http://127.0.0.1:5000> to sign in and explore the prototype.
+
+### QR Code Processing
+
+When a buyer selects an item on the merchant page, the app generates a QR code encoding the product ID, buyer, and price. Merchants can scan the code (or open the processing URL) to complete the transaction and update stock levels.
+
+### Tests
+
+This prototype does not yet include automated tests. Please exercise the flows manually.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,7 @@
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,73 @@
+import os
+from datetime import datetime
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from authlib.integrations.flask_client import OAuth
+
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+oauth = OAuth()
+
+
+def create_app(test_config=None):
+    app = Flask(__name__)
+    app.config.from_mapping(
+        SECRET_KEY=os.environ.get("SECRET_KEY", "dev"),
+        SQLALCHEMY_DATABASE_URI=os.environ.get(
+            "DATABASE_URL", f"sqlite:///{os.path.join(app.instance_path, 'app.sqlite')}"
+        ),
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        GOOGLE_CLIENT_ID=os.environ.get("GOOGLE_CLIENT_ID", ""),
+        GOOGLE_CLIENT_SECRET=os.environ.get("GOOGLE_CLIENT_SECRET", ""),
+    )
+
+    if test_config is not None:
+        app.config.update(test_config)
+
+    try:
+        os.makedirs(app.instance_path, exist_ok=True)
+    except OSError:
+        pass
+
+    db.init_app(app)
+    login_manager.init_app(app)
+    login_manager.login_view = "auth.login"
+
+    oauth.init_app(app)
+    if app.config["GOOGLE_CLIENT_ID"] and app.config["GOOGLE_CLIENT_SECRET"]:
+        oauth.register(
+            name="google",
+            client_id=app.config["GOOGLE_CLIENT_ID"],
+            client_secret=app.config["GOOGLE_CLIENT_SECRET"],
+            server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+            client_kwargs={"scope": "openid email profile"},
+        )
+
+    from . import models  # noqa: F401
+    from .auth import bp as auth_bp
+    from .routes import bp as main_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(main_bp)
+
+    register_cli_commands(app)
+
+    @app.context_processor
+    def inject_now():
+        return {"now": datetime.utcnow()}
+
+    return app
+
+
+def register_cli_commands(app):
+    @app.cli.command("init-db")
+    def init_db_command():
+        """Clear existing data and create new tables."""
+        from .models import db
+
+        db.drop_all()
+        db.create_all()
+        print("Initialized the database.")

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,88 @@
+from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask_login import current_user, login_required, login_user, logout_user
+
+from . import db, oauth
+from .models import Role, User
+
+
+bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+def require_oauth():
+    provider = oauth.create_client("google") if "google" in oauth._clients else None
+    if provider is None:
+        flash(
+            "Google OAuth is not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.",
+            "error",
+        )
+        return False
+    return True
+
+
+@bp.route("/login")
+def login():
+    if current_user.is_authenticated:
+        return redirect(url_for("main.dashboard"))
+    if not require_oauth():
+        return render_template("login.html", allow_guest=True)
+    redirect_uri = url_for("auth.authorize", _external=True)
+    return oauth.google.authorize_redirect(redirect_uri)
+
+
+@bp.route("/authorize")
+def authorize():
+    if not require_oauth():
+        return redirect(url_for("main.index"))
+    token = oauth.google.authorize_access_token()
+    user_info = token.get("userinfo")
+    if not user_info:
+        user_info = oauth.google.parse_id_token(token)
+    if user_info is None:
+        flash("Unable to fetch user information from Google.", "error")
+        return redirect(url_for("main.index"))
+
+    google_id = user_info["sub"]
+    email = user_info.get("email")
+    name = user_info.get("name") or email
+
+    user = User.query.filter_by(google_id=google_id).first()
+    if not user:
+        user = User(google_id=google_id, email=email, name=name, role=Role.PLAYER)
+        db.session.add(user)
+        db.session.commit()
+
+    login_user(user)
+    session["token"] = token
+    flash(f"Welcome, {user.name}!", "success")
+    return redirect(url_for("main.dashboard"))
+
+
+@bp.route("/logout")
+@login_required
+def logout():
+    logout_user()
+    session.pop("token", None)
+    flash("You have been signed out.", "info")
+    return redirect(url_for("main.index"))
+
+
+@bp.route("/guest-login", methods=["POST"])
+def guest_login():
+    if current_user.is_authenticated:
+        return redirect(url_for("main.dashboard"))
+
+    user = User.query.filter_by(google_id="guest").first()
+    if not user:
+        user = User(
+            google_id="guest",
+            email="guest@example.com",
+            name="Guest",
+            role=Role.PLAYER,
+        )
+        db.session.add(user)
+        db.session.commit()
+
+    login_user(user)
+    session["token"] = {"userinfo": {"name": user.name}}
+    flash("Signed in temporarily as Guest.", "info")
+    return redirect(url_for("main.dashboard"))

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,124 @@
+from datetime import datetime
+from enum import Enum
+
+from flask_login import UserMixin
+from sqlalchemy import CheckConstraint, Enum as SqlEnum
+
+from . import db, login_manager
+
+
+class Role(str, Enum):
+    PLAYER = "player"
+    MERCHANT = "merchant"
+    ADMIN = "admin"
+
+    @property
+    def level(self) -> int:
+        return {
+            Role.PLAYER: 0,
+            Role.MERCHANT: 1,
+            Role.ADMIN: 2,
+        }[self]
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    google_id = db.Column(db.String(255), unique=True, nullable=False)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    name = db.Column(db.String(255), nullable=False)
+    balance = db.Column(db.Float, default=0.0, nullable=False)
+    role = db.Column(SqlEnum(Role), default=Role.PLAYER, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    transactions = db.relationship("Transaction", backref="user", lazy=True)
+
+    def get_id(self):
+        return str(self.id)
+
+    @property
+    def is_admin(self):
+        return self.has_privilege(Role.ADMIN)
+
+    @property
+    def is_merchant(self):
+        return self.has_privilege(Role.MERCHANT)
+
+    @property
+    def is_player(self):
+        return self.has_privilege(Role.PLAYER)
+
+    def has_privilege(self, role: Role) -> bool:
+        return self.role.level >= role.level
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    description = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    counterparty_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    type = db.Column(db.String(50), nullable=False, default="game")
+
+    counterparty = db.relationship("User", foreign_keys=[counterparty_id], lazy=True)
+
+
+class Product(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.String(255), nullable=True)
+    price = db.Column(db.Float, nullable=False)
+    stock = db.Column(db.Integer, nullable=False, default=0)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    price_history = db.relationship("PriceHistory", backref="product", lazy=True)
+
+    __table_args__ = (CheckConstraint("price >= 0"), CheckConstraint("stock >= 0"),)
+
+
+class PriceHistory(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    product_id = db.Column(db.Integer, db.ForeignKey("product.id"), nullable=False)
+    price = db.Column(db.Float, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class QueueEntry(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    user = db.relationship("User", lazy=True)
+
+    __table_args__ = (db.UniqueConstraint("user_id", name="uq_queue_user"),)
+
+
+class PrisonersMatch(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    player1_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    player2_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    player1_choice = db.Column(db.String(20), nullable=True)
+    player2_choice = db.Column(db.String(20), nullable=True)
+    status = db.Column(db.String(20), default="waiting", nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    resolved_at = db.Column(db.DateTime, nullable=True)
+
+    player1 = db.relationship("User", foreign_keys=[player1_id])
+    player2 = db.relationship("User", foreign_keys=[player2_id])
+
+    def is_participant(self, user):
+        return user.id in {self.player1_id, self.player2_id}
+
+    def record_choice(self, user, choice):
+        if user.id == self.player1_id:
+            self.player1_choice = choice
+        elif user.id == self.player2_id:
+            self.player2_choice = choice
+
+    def both_choices_made(self):
+        return self.player1_choice is not None and self.player2_choice is not None

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,413 @@
+import base64
+import io
+from datetime import datetime
+
+import qrcode
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_login import current_user, login_required
+
+from . import db
+from .models import (
+    PriceHistory,
+    PrisonersMatch,
+    Product,
+    QueueEntry,
+    Role,
+    Transaction,
+    User,
+)
+
+
+bp = Blueprint("main", __name__)
+
+
+def record_transaction(user, amount, description, counterparty=None, type_="game", commit=True):
+    user.balance += amount
+    txn = Transaction(
+        user=user,
+        amount=amount,
+        description=description,
+        counterparty=counterparty,
+        type=type_,
+    )
+    db.session.add(txn)
+    if commit:
+        db.session.commit()
+    return txn
+
+
+@bp.route("/")
+def index():
+    return render_template("index.html")
+
+
+@bp.route("/dashboard")
+@login_required
+def dashboard():
+    latest_transactions = (
+        Transaction.query.filter_by(user_id=current_user.id)
+        .order_by(Transaction.created_at.desc())
+        .limit(10)
+        .all()
+    )
+    active_match = (
+        PrisonersMatch.query.filter(
+            PrisonersMatch.status != "completed",
+            ((PrisonersMatch.player1_id == current_user.id) | (PrisonersMatch.player2_id == current_user.id)),
+        )
+        .order_by(PrisonersMatch.created_at.desc())
+        .first()
+    )
+    return render_template(
+        "dashboard.html",
+        balance=current_user.balance,
+        transactions=latest_transactions,
+        active_match=active_match,
+    )
+
+
+@bp.route("/single-player", methods=["GET", "POST"])
+@login_required
+def single_player():
+    reward = 5.0
+    if request.method == "POST":
+        record_transaction(current_user, reward, "Won the solo clicker game")
+        flash(f"You earned {reward:.2f} credits!", "success")
+        return redirect(url_for("main.single_player"))
+    return render_template("single_player.html", reward=reward)
+
+
+@bp.route("/prisoners", methods=["GET", "POST"])
+@login_required
+def prisoners_dilemma():
+    match = get_active_match_for_user(current_user)
+    waiting_entry = QueueEntry.query.filter_by(user_id=current_user.id).first()
+    if request.method == "POST":
+        action = request.form.get("action")
+        if action == "join_queue":
+            if match:
+                flash("You are already in a match.", "warning")
+            else:
+                join_queue(current_user)
+        elif action == "leave_queue":
+            leave_queue(current_user)
+        elif action in {"cooperate", "defect"}:
+            if not match:
+                flash("You are not currently in a match.", "warning")
+            else:
+                submit_choice(match, current_user, action)
+        return redirect(url_for("main.prisoners_dilemma"))
+
+    match = get_active_match_for_user(current_user)
+    waiting_entry = QueueEntry.query.filter_by(user_id=current_user.id).first()
+    return render_template(
+        "prisoners_dilemma.html",
+        match=match,
+        waiting=waiting_entry is not None,
+        opponent=get_opponent(match, current_user) if match else None,
+    )
+
+
+def get_active_match_for_user(user):
+    return (
+        PrisonersMatch.query.filter(
+            PrisonersMatch.status != "completed",
+            ((PrisonersMatch.player1_id == user.id) | (PrisonersMatch.player2_id == user.id)),
+        )
+        .order_by(PrisonersMatch.created_at.desc())
+        .first()
+    )
+
+
+def get_opponent(match, user):
+    if match is None:
+        return None
+    if match.player1_id == user.id:
+        return match.player2
+    return match.player1
+
+
+def join_queue(user):
+    waiting_entry = QueueEntry.query.order_by(QueueEntry.created_at.asc()).first()
+    if waiting_entry and waiting_entry.user_id != user.id:
+        match = PrisonersMatch(
+            player1_id=waiting_entry.user_id,
+            player2_id=user.id,
+            status="in_progress",
+        )
+        db.session.add(match)
+        db.session.delete(waiting_entry)
+        db.session.commit()
+        flash("You have been matched!", "success")
+        return match
+    elif waiting_entry and waiting_entry.user_id == user.id:
+        flash("You are already waiting for an opponent.", "info")
+    else:
+        db.session.add(QueueEntry(user_id=user.id))
+        db.session.commit()
+        flash("Joined the queue. Waiting for an opponent.", "info")
+    return None
+
+
+def leave_queue(user):
+    waiting_entry = QueueEntry.query.filter_by(user_id=user.id).first()
+    if waiting_entry:
+        db.session.delete(waiting_entry)
+        db.session.commit()
+        flash("You left the queue.", "info")
+    else:
+        flash("You are not currently in the queue.", "warning")
+
+
+PAYOFFS = {
+    ("cooperate", "cooperate"): (5, 5),
+    ("cooperate", "defect"): (-10, 15),
+    ("defect", "cooperate"): (15, -10),
+    ("defect", "defect"): (-5, -5),
+}
+
+
+def submit_choice(match, user, choice):
+    if match.status != "in_progress":
+        flash("This match is no longer active.", "warning")
+        return
+    match.record_choice(user, choice)
+    db.session.commit()
+    if match.both_choices_made():
+        resolve_match(match)
+
+
+def resolve_match(match):
+    payoff = PAYOFFS[(match.player1_choice, match.player2_choice)]
+    player1 = match.player1
+    player2 = match.player2
+    record_transaction(player1, payoff[0], f"Prisoner's dilemma: {match.player1_choice}", counterparty=player2)
+    record_transaction(player2, payoff[1], f"Prisoner's dilemma: {match.player2_choice}", counterparty=player1)
+    match.status = "completed"
+    match.resolved_at = datetime.utcnow()
+    db.session.commit()
+    flash(
+        f"Match resolved! Results: {player1.name} chose {match.player1_choice}, {player2.name} chose {match.player2_choice}.",
+        "info",
+    )
+
+
+@bp.route("/merchant", methods=["GET", "POST"])
+@login_required
+def merchant_portal():
+    products = Product.query.order_by(Product.name.asc()).all()
+    selected_product = None
+    qr_data_uri = None
+    buyer_id = current_user.id
+
+    if request.method == "POST":
+        action = request.form.get("action")
+        product_id = request.form.get("product_id")
+        if action == "select" and product_id:
+            selected_product = Product.query.get(int(product_id))
+            if selected_product:
+                qr_data_uri = build_qr_for_product(selected_product, buyer_id)
+        elif action in {"update_price", "update_stock"} and product_id:
+            product = Product.query.get(int(product_id))
+            if not product:
+                flash("Product not found.", "error")
+            elif not current_user.is_merchant:
+                flash("Only merchants can update inventory.", "error")
+            else:
+                if action == "update_price":
+                    new_price = float(request.form.get("price", product.price))
+                    update_price(product, new_price)
+                else:
+                    new_stock = int(request.form.get("stock", product.stock))
+                    product.stock = max(0, new_stock)
+                    product.updated_at = datetime.utcnow()
+                    db.session.commit()
+                    flash("Stock updated.", "success")
+                return redirect(url_for("main.merchant_portal"))
+        elif action == "add_product" and current_user.is_merchant:
+            name = request.form.get("name")
+            price = float(request.form.get("price", 0))
+            stock = int(request.form.get("stock", 0))
+            description = request.form.get("description")
+            if name:
+                product = Product(name=name, price=price, stock=stock, description=description)
+                db.session.add(product)
+                db.session.commit()
+                update_price(product, price)
+                flash("Product created.", "success")
+            return redirect(url_for("main.merchant_portal"))
+        else:
+            return redirect(url_for("main.merchant_portal"))
+
+    return render_template(
+        "merchant.html",
+        products=products,
+        selected_product=selected_product,
+        qr_data_uri=qr_data_uri,
+    )
+
+
+def update_price(product, new_price):
+    product.price = max(0, new_price)
+    product.updated_at = datetime.utcnow()
+    db.session.add(PriceHistory(product=product, price=product.price))
+    db.session.commit()
+    flash("Price updated.", "success")
+
+
+def build_qr_for_product(product, buyer_id):
+    payload = {
+        "product_id": product.id,
+        "buyer_id": buyer_id,
+        "price": product.price,
+    }
+    qr = qrcode.QRCode(version=1, error_correction=qrcode.constants.ERROR_CORRECT_L)
+    qr.add_data(str(payload))
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    data = base64.b64encode(buf.getvalue()).decode("utf-8")
+    return f"data:image/png;base64,{data}"
+
+
+@bp.route("/merchant/process/<int:product_id>", methods=["GET", "POST"])
+@login_required
+def process_sale(product_id):
+    product = Product.query.get_or_404(product_id)
+    buyer_id = request.args.get("buyer_id", type=int)
+    buyer = User.query.get(buyer_id) if buyer_id else None
+    if not current_user.is_merchant:
+        abort(403)
+
+    if request.method == "POST":
+        if not buyer:
+            flash("Buyer information missing.", "error")
+            return redirect(url_for("main.merchant_portal"))
+        if product.stock <= 0:
+            flash("Product out of stock.", "error")
+            return redirect(url_for("main.merchant_portal"))
+        product.stock -= 1
+        product.updated_at = datetime.utcnow()
+        record_transaction(
+            buyer,
+            -product.price,
+            f"Purchased {product.name}",
+            counterparty=current_user,
+            type_="purchase",
+            commit=False,
+        )
+        record_transaction(
+            current_user,
+            product.price,
+            f"Sold {product.name}",
+            counterparty=buyer,
+            type_="sale",
+            commit=False,
+        )
+        db.session.commit()
+        flash("Sale completed.", "success")
+        return redirect(url_for("main.merchant_portal"))
+
+    qr_data_uri = build_qr_for_product(product, buyer_id or current_user.id)
+    return render_template(
+        "process_sale.html",
+        product=product,
+        buyer=buyer,
+        qr_data_uri=qr_data_uri,
+    )
+
+
+@bp.route("/admin")
+@login_required
+def admin_dashboard():
+    if not current_user.is_admin:
+        abort(403)
+    products = Product.query.order_by(Product.name).all()
+    users = User.query.order_by(User.name).all()
+    price_history = PriceHistory.query.order_by(PriceHistory.timestamp.desc()).limit(50).all()
+    recent_transactions = Transaction.query.order_by(Transaction.created_at.desc()).limit(20).all()
+    stats = build_price_stats(products)
+    return render_template(
+        "admin.html",
+        products=products,
+        price_history=price_history,
+        transactions=recent_transactions,
+        stats=stats,
+        users=users,
+    )
+
+
+@bp.route("/admin/assign-role", methods=["POST"])
+@login_required
+def assign_role():
+    if not current_user.is_admin:
+        abort(403)
+    user_id = request.form.get("user_id", type=int)
+    role_name = request.form.get("role")
+    user = User.query.get_or_404(user_id)
+    if role_name not in Role._value2member_map_:
+        flash("Invalid role.", "error")
+    else:
+        user.role = Role(role_name)
+        db.session.commit()
+        flash("Role updated.", "success")
+    return redirect(url_for("main.admin_dashboard"))
+
+
+@bp.route("/admin/transactions")
+@login_required
+def admin_transactions_feed():
+    if not current_user.is_admin:
+        abort(403)
+    transactions = (
+        Transaction.query.order_by(Transaction.created_at.desc())
+        .limit(20)
+        .all()
+    )
+    data = [
+        {
+            "id": txn.id,
+            "user": txn.user.name,
+            "amount": txn.amount,
+            "description": txn.description,
+            "timestamp": txn.created_at.isoformat(),
+        }
+        for txn in transactions
+    ]
+    return jsonify(data)
+
+
+def build_price_stats(products):
+    stats = []
+    for product in products:
+        history = (
+            PriceHistory.query.filter_by(product_id=product.id)
+            .order_by(PriceHistory.timestamp.asc())
+            .all()
+        )
+        if not history:
+            continue
+        first = history[0].price
+        latest = history[-1].price
+        change = latest - first
+        percent = (change / first * 100) if first else 0
+        stats.append(
+            {
+                "product": product,
+                "initial_price": first,
+                "latest_price": latest,
+                "change": change,
+                "percent_change": percent,
+            }
+        )
+    return stats

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,271 @@
+:root {
+  --bg: #101820;
+  --panel: #1f2a33;
+  --accent: #1affd5;
+  --accent-strong: #00bfa5;
+  --text: #e6f1ff;
+  --muted: #78909c;
+  --danger: #ff4f64;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Roboto Mono', monospace;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+  padding: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.app-header,
+.app-footer {
+  background: #0b141b;
+  color: var(--text);
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.4);
+}
+
+.app-footer {
+  justify-content: center;
+  font-size: 0.85rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.logo {
+  font-size: 1.5rem;
+  color: var(--accent);
+}
+
+.main-nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.main-nav a {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.main-nav a:hover {
+  color: var(--accent);
+}
+
+.balance {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.hero {
+  background: var(--panel);
+  padding: 2rem;
+  border: 2px solid var(--accent);
+  text-align: center;
+  border-radius: 8px;
+}
+
+.button,
+button {
+  background: transparent;
+  border: 2px solid var(--accent);
+  color: var(--text);
+  padding: 0.6rem 1.2rem;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.button.primary,
+button.primary {
+  background: var(--accent);
+  color: #001217;
+}
+
+.button:hover,
+button:hover {
+  background: var(--accent-strong);
+  color: #001217;
+}
+
+.button.danger,
+button.danger {
+  border-color: var(--danger);
+}
+
+.button.danger:hover,
+button.danger:hover {
+  background: var(--danger);
+  color: #001217;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  box-shadow: inset 0 0 0 2px rgba(26, 255, 213, 0.08);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.1);
+  font-size: 0.9rem;
+}
+
+.list li:last-child {
+  border-bottom: none;
+}
+
+.amount.positive {
+  color: var(--accent);
+}
+
+.amount.negative {
+  color: var(--danger);
+}
+
+.flash-messages {
+  margin-bottom: 1rem;
+}
+
+.flash {
+  padding: 0.8rem 1rem;
+  border-left: 4px solid var(--accent);
+  background: rgba(26, 255, 213, 0.08);
+  margin-bottom: 0.5rem;
+}
+
+.flash.error {
+  border-color: var(--danger);
+  background: rgba(255, 79, 100, 0.12);
+}
+
+.flash.success {
+  border-color: var(--accent);
+}
+
+.flash.warning {
+  border-color: #ffb300;
+  background: rgba(255, 179, 0, 0.12);
+}
+
+.form label {
+  display: block;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.form input,
+.form select {
+  width: 100%;
+  padding: 0.5rem;
+  background: #0f161d;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  border-radius: 4px;
+  margin-top: 0.4rem;
+}
+
+.inline-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.inline-form .link {
+  border: none;
+  background: none;
+  color: var(--accent);
+  padding: 0;
+  cursor: pointer;
+}
+
+.inline-form .link:hover {
+  text-decoration: underline;
+}
+
+.qr {
+  max-width: 220px;
+  margin-top: 1rem;
+  border: 4px solid rgba(26, 255, 213, 0.25);
+  border-radius: 8px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+  font-size: 0.85rem;
+}
+
+.note {
+  color: var(--muted);
+  font-size: 0.8rem;
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 1rem;
+  }
+
+  .main-nav {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,85 @@
+{% extends 'base.html' %}
+{% block title %}Admin Dashboard{% endblock %}
+{% block content %}
+<section class="grid">
+  <article class="panel">
+    <h2>Price Movement</h2>
+    <table class="table">
+      <thead>
+        <tr><th>Product</th><th>Initial</th><th>Latest</th><th>Change</th><th>%</th></tr>
+      </thead>
+      <tbody>
+        {% for row in stats %}
+          <tr>
+            <td>{{ row.product.name }}</td>
+            <td>{{ '%.2f'|format(row.initial_price) }}</td>
+            <td>{{ '%.2f'|format(row.latest_price) }}</td>
+            <td class="amount {{ 'positive' if row.change >= 0 else 'negative' }}">{{ '%.2f'|format(row.change) }}</td>
+            <td>{{ '%.1f'|format(row.percent_change) }}%</td>
+          </tr>
+        {% else %}
+          <tr><td colspan="5">No price history yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </article>
+
+  <article class="panel">
+    <h2>Recent Transactions</h2>
+    <ul class="list" id="txn-feed">
+      {% for txn in transactions %}
+        <li data-id="{{ txn.id }}">
+          <span>{{ txn.created_at.strftime('%H:%M:%S') }}</span>
+          <span>{{ txn.user.name }} — {{ txn.description }}</span>
+          <span class="amount {{ 'positive' if txn.amount >= 0 else 'negative' }}">{{ '%.2f'|format(txn.amount) }}</span>
+        </li>
+      {% else %}
+        <li>No transactions yet.</li>
+      {% endfor %}
+    </ul>
+  </article>
+
+  <article class="panel">
+    <h2>Assign Roles</h2>
+    <form method="post" action="{{ url_for('main.assign_role') }}" class="form">
+      <label>User
+        <select name="user_id" required>
+          {% for user in users %}
+            <option value="{{ user.id }}">{{ user.name }} ({{ user.role.value }})</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Role
+        <select name="role" required>
+          {% for role in ['player', 'merchant', 'admin'] %}
+            <option value="{{ role }}">{{ role|capitalize }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <button class="button" type="submit">Assign</button>
+    </form>
+    <p class="note">Use the Flask shell to create the first admin or adjust roles directly.</p>
+  </article>
+</section>
+
+<script>
+async function refreshTransactions() {
+  const response = await fetch('{{ url_for('main.admin_transactions_feed') }}');
+  if (!response.ok) return;
+  const data = await response.json();
+  const list = document.getElementById('txn-feed');
+  list.innerHTML = '';
+  data.forEach(item => {
+    const li = document.createElement('li');
+    li.dataset.id = item.id;
+    li.innerHTML = `
+      <span>${new Date(item.timestamp).toLocaleTimeString()}</span>
+      <span>${item.user} — ${item.description}</span>
+      <span class="amount ${item.amount >= 0 ? 'positive' : 'negative'}">${item.amount.toFixed(2)}</span>
+    `;
+    list.appendChild(li);
+  });
+}
+setInterval(refreshTransactions, 5000);
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Invisible Hand Arcade{% endblock %}</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="brand">
+        <span class="logo">∞</span>
+        <span>Invisible Hand Arcade</span>
+      </div>
+      <nav class="main-nav">
+        <a href="{{ url_for('main.index') }}">Home</a>
+        {% if current_user.is_authenticated %}
+          <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
+          <a href="{{ url_for('main.single_player') }}">Solo Game</a>
+          <a href="{{ url_for('main.prisoners_dilemma') }}">Prisoner's Dilemma</a>
+          <a href="{{ url_for('main.merchant_portal') }}">Merchant</a>
+          {% if current_user.is_admin %}
+            <a href="{{ url_for('main.admin_dashboard') }}">Admin</a>
+          {% endif %}
+          <span class="balance">Balance: {{ '%.2f'|format(current_user.balance) }}</span>
+          <a href="{{ url_for('auth.logout') }}">Sign out</a>
+        {% else %}
+          <a href="{{ url_for('auth.login') }}">Sign in</a>
+        {% endif %}
+      </nav>
+    </header>
+
+    <main>
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <section class="flash-messages">
+            {% for category, message in messages %}
+              <div class="flash {{ category }}">{{ message }}</div>
+            {% endfor %}
+          </section>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="app-footer">
+      Crafted for social strategy nights · {{ now.year }}
+    </footer>
+  </body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<section class="grid">
+  <article class="panel">
+    <h2>{{ current_user.name }}</h2>
+    <p class="stat">Balance: <strong>{{ '%.2f'|format(balance) }}</strong></p>
+    <p class="stat">Role: <strong>{{ current_user.role.value|capitalize }}</strong></p>
+    <div class="actions">
+      <a class="button" href="{{ url_for('main.single_player') }}">Play solo game</a>
+      <a class="button" href="{{ url_for('main.prisoners_dilemma') }}">Enter Prisoner's Dilemma</a>
+    </div>
+  </article>
+  <article class="panel">
+    <h3>Recent Transactions</h3>
+    <ul class="list">
+      {% for txn in transactions %}
+        <li>
+          <span>{{ txn.created_at.strftime('%H:%M:%S') }}</span>
+          <span>{{ txn.description }}</span>
+          <span class="amount {{ 'positive' if txn.amount >= 0 else 'negative' }}">{{ '%.2f'|format(txn.amount) }}</span>
+        </li>
+      {% else %}
+        <li>No transactions yet.</li>
+      {% endfor %}
+    </ul>
+  </article>
+  {% if active_match %}
+    <article class="panel">
+      <h3>Active Match</h3>
+      <p>You are matched with {{ active_match.player1.name if active_match.player2_id == current_user.id else active_match.player2.name }}.</p>
+      <p>Status: {{ active_match.status|replace('_', ' ')|title }}</p>
+      {% if active_match.status != 'completed' %}
+        <a class="button" href="{{ url_for('main.prisoners_dilemma') }}">Go to match</a>
+      {% endif %}
+    </article>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}Invisible Hand Arcade{% endblock %}
+{% block content %}
+<section class="hero">
+  <h1>Social Hour, Powered by Games</h1>
+  <p>Compete, cooperate, and earn credits to trade for snacks and prizes. Sign in to start playing.</p>
+  {% if not current_user.is_authenticated %}
+    <a class="button primary" href="{{ url_for('auth.login') }}">Sign in with Google</a>
+  {% else %}
+    <a class="button" href="{{ url_for('main.dashboard') }}">Go to Dashboard</a>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Sign in{% endblock %}
+{% block content %}
+<section class="panel">
+  <h2>Sign in</h2>
+  <p>Google OAuth is not configured. Set <code>GOOGLE_CLIENT_ID</code> and <code>GOOGLE_CLIENT_SECRET</code> to enable authentication.</p>
+  {% if allow_guest %}
+  <form action="{{ url_for('auth.guest_login') }}" method="post" class="form">
+    <button type="submit" class="button">Continue as Guest</button>
+    <p class="hint">Temporary access with a shared guest account.</p>
+  </form>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/merchant.html
+++ b/app/templates/merchant.html
@@ -1,0 +1,82 @@
+{% extends 'base.html' %}
+{% block title %}Merchant Portal{% endblock %}
+{% block content %}
+<section class="grid">
+  <article class="panel">
+    <h2>Products</h2>
+    <ul class="list">
+      {% for product in products %}
+        <li>
+          <form method="post" class="inline-form">
+            <input type="hidden" name="product_id" value="{{ product.id }}">
+            <button class="link" name="action" value="select">{{ product.name }}</button>
+            <span class="amount">{{ '%.2f'|format(product.price) }}</span>
+            <span class="note">Stock: {{ product.stock }}</span>
+          </form>
+        </li>
+      {% else %}
+        <li>No products yet.</li>
+      {% endfor %}
+    </ul>
+  </article>
+
+  <article class="panel">
+    <h2>Create product</h2>
+    {% if current_user.is_merchant %}
+      <form method="post" class="form">
+        <input type="hidden" name="action" value="add_product">
+        <label>Name<input type="text" name="name" required></label>
+        <label>Description<input type="text" name="description"></label>
+        <label>Price<input type="number" step="0.01" name="price" required></label>
+        <label>Stock<input type="number" name="stock" min="0" value="0"></label>
+        <button class="button" type="submit">Add product</button>
+      </form>
+    {% else %}
+      <p>Only merchants can add products.</p>
+    {% endif %}
+  </article>
+
+  <article class="panel">
+    <h2>QR Checkout</h2>
+    {% if selected_product %}
+      <p>{{ selected_product.name }} — {{ '%.2f'|format(selected_product.price) }} credits</p>
+      <img class="qr" src="{{ qr_data_uri }}" alt="QR code for {{ selected_product.name }}">
+      {% if current_user.is_merchant %}
+        <a class="button" href="{{ url_for('main.process_sale', product_id=selected_product.id, buyer_id=current_user.id) }}">Process self-purchase</a>
+      {% endif %}
+    {% else %}
+      <p>Select a product to generate a QR code.</p>
+    {% endif %}
+  </article>
+
+  {% if current_user.is_merchant %}
+  <article class="panel">
+    <h2>Inventory adjustments</h2>
+    <form method="post" class="form">
+      <input type="hidden" name="action" value="update_price">
+      <label>Product
+        <select name="product_id" required>
+          {% for product in products %}
+            <option value="{{ product.id }}">{{ product.name }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>New price<input type="number" step="0.01" name="price" required></label>
+      <button class="button" type="submit">Update price</button>
+    </form>
+    <form method="post" class="form">
+      <input type="hidden" name="action" value="update_stock">
+      <label>Product
+        <select name="product_id" required>
+          {% for product in products %}
+            <option value="{{ product.id }}">{{ product.name }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>New stock<input type="number" name="stock" min="0" required></label>
+      <button class="button" type="submit">Update stock</button>
+    </form>
+  </article>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/prisoners_dilemma.html
+++ b/app/templates/prisoners_dilemma.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block title %}Prisoner's Dilemma{% endblock %}
+{% block content %}
+<section class="panel game">
+  <h2>Prisoner's Dilemma</h2>
+  {% if match %}
+    <p>Opponent: {{ opponent.name }}</p>
+    {% if match.status == 'completed' %}
+      <p>The match has concluded. Check your dashboard for the results.</p>
+    {% else %}
+      <form method="post" class="inline-form">
+        <button class="button" name="action" value="cooperate">Cooperate</button>
+        <button class="button danger" name="action" value="defect">Defect</button>
+      </form>
+      <p class="note">Cooperate: both earn 5. Defect: earn 15 but your opponent loses 10. If both defect, both lose 5.</p>
+    {% endif %}
+  {% elif waiting %}
+    <p>You are in the matchmaking queue.</p>
+    <form method="post">
+      <button class="button" name="action" value="leave_queue">Leave queue</button>
+    </form>
+  {% else %}
+    <p>Queue up to find an opponent.</p>
+    <form method="post">
+      <button class="button primary" name="action" value="join_queue">Join queue</button>
+    </form>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/process_sale.html
+++ b/app/templates/process_sale.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Process Sale{% endblock %}
+{% block content %}
+<section class="panel">
+  <h2>Process Sale</h2>
+  <p>Product: {{ product.name }}</p>
+  <p>Price: {{ '%.2f'|format(product.price) }}</p>
+  <p>Buyer: {{ buyer.name if buyer else 'Unknown' }}</p>
+  <img class="qr" src="{{ qr_data_uri }}" alt="QR code for {{ product.name }}">
+  <form method="post">
+    <button class="button primary" type="submit">Complete transaction</button>
+  </form>
+</section>
+{% endblock %}

--- a/app/templates/single_player.html
+++ b/app/templates/single_player.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Solo Game{% endblock %}
+{% block content %}
+<section class="panel game">
+  <h2>Incremental Clicker Prototype</h2>
+  <p>Tap the button to run a profitable side hustle and earn credits.</p>
+  <form method="post">
+    <button class="button primary" type="submit">Run the hustle (+{{ '%.2f'|format(reward) }})</button>
+  </form>
+</section>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "invisible-hand"
+version = "0.1.0"
+description = "Flask arcade prototype with Google OAuth, minigames, and merchant/admin dashboards"
+readme = "README.md"
+authors = [
+  { name = "Invisible Hand Team" }
+]
+requires-python = ">=3.10"
+dependencies = [
+  "Flask==2.3.2",
+  "Flask-Login==0.6.2",
+  "Flask-SQLAlchemy==3.0.5",
+  "Authlib==1.2.1",
+  "qrcode==7.4.2",
+  "Pillow==10.0.0"
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv]
+package = false


### PR DESCRIPTION
## Summary
- add an explicit privilege level to each role so capabilities cascade from player to merchant to admin
- centralize privilege checks on the User model to expose reusable helpers for player, merchant, and admin access

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d082599bb48332b3de53fa15ce2dfd