### PR TITLE
Implement hierarchical role privileges

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,15 @@ class Role(str, Enum):
     MERCHANT = "merchant"
     ADMIN = "admin"
 
+    _LEVELS = {
+        PLAYER: 0,
+        MERCHANT: 1,
+        ADMIN: 2,
+    }
+
+    def at_least(self, other: "Role") -> bool:
+        return self._LEVELS[self] >= self._LEVELS[other]
+
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -33,13 +42,16 @@ class User(UserMixin, db.Model):
     def get_id(self):
         return str(self.id)
 
+    def has_privilege(self, role: Role) -> bool:
+        return self.role.at_least(role)
+
     @property
     def is_admin(self):
-        return self.role == Role.ADMIN
+        return self.has_privilege(Role.ADMIN)
 
     @property
     def is_merchant(self):
-        return self.role in {Role.MERCHANT, Role.ADMIN}
+        return self.has_privilege(Role.MERCHANT)
 
 
 @login_manager.user_loader

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,7 +19,9 @@
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
           <a href="{{ url_for('main.single_player') }}">Solo Game</a>
           <a href="{{ url_for('main.prisoners_dilemma') }}">Prisoner's Dilemma</a>
-          <a href="{{ url_for('main.merchant_portal') }}">Merchant</a>
+          {% if current_user.is_merchant %}
+            <a href="{{ url_for('main.merchant_portal') }}">Merchant</a>
+          {% endif %}
           {% if current_user.is_admin %}
             <a href="{{ url_for('main.admin_dashboard') }}">Admin</a>
           {% endif %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -10,6 +10,12 @@
     <div class="actions">
       <a class="button" href="{{ url_for('main.single_player') }}">Play solo game</a>
       <a class="button" href="{{ url_for('main.prisoners_dilemma') }}">Enter Prisoner's Dilemma</a>
+      {% if current_user.is_merchant %}
+        <a class="button" href="{{ url_for('main.merchant_portal') }}">Open Merchant Portal</a>
+      {% endif %}
+      {% if current_user.is_admin %}
+        <a class="button" href="{{ url_for('main.admin_dashboard') }}">Admin Dashboard</a>
+      {% endif %}
     </div>
   </article>
   <article class="panel">


### PR DESCRIPTION
## Summary
- define a role hierarchy so each role can be compared by privilege level
- add a reusable `User.has_privilege` helper and update merchant/admin checks to use it
- surface merchant and admin interfaces in the UI only for users with the matching privileges

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a11de3348332bca8c1dc7703c27b