### PR TITLE
Add securities market simulation with derivatives

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,11 +49,13 @@ def create_app(test_config=None):
     from . import models  # noqa: F401
     from .auth import bp as auth_bp
     from .routes import bp as main_bp
+    from .securities import init_market
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
 
     register_cli_commands(app)
+    init_market(app)
 
     @app.context_processor
     def inject_now():

--- a/app/config/securities.toml
+++ b/app/config/securities.toml
@@ -1,0 +1,47 @@
+[risk]
+risk_free_rate = 0.015
+
+[market]
+update_interval_seconds = 5
+
+[securities.FLY]
+name = "FlightLift Yield Cooperative"
+description = "A consortium of drone pilots and cargo dirigibles that profit from the logistics boom."
+initial_price = 128.0
+drift = 0.035
+volatility = 0.28
+mean_reversion = 0.55
+fundamental_value = 130.0
+liquidity = 0.45
+impact = 0.018
+options_tenors = [7, 21, 45]
+options_strike_multipliers = [0.9, 1.0, 1.1]
+futures_tenors = [14, 35]
+
+[securities.CT]
+name = "Carbon Tether"
+description = "Tokenized carbon removal contracts with regulated off-take agreements."
+initial_price = 42.0
+drift = 0.02
+volatility = 0.18
+mean_reversion = 0.75
+fundamental_value = 40.0
+liquidity = 0.6
+impact = 0.012
+options_tenors = [14, 30, 60]
+options_strike_multipliers = [0.85, 1.0, 1.15]
+futures_tenors = [30, 60]
+
+[securities.MS]
+name = "Metasynaptic Systems"
+description = "Brain-computer interface firmware with cyclical hardware demand."
+initial_price = 215.0
+drift = 0.05
+volatility = 0.35
+mean_reversion = 0.5
+fundamental_value = 210.0
+liquidity = 0.35
+impact = 0.022
+options_tenors = [7, 28, 56]
+options_strike_multipliers = [0.85, 1.0, 1.2]
+futures_tenors = [21, 63]

--- a/app/models.py
+++ b/app/models.py
@@ -50,6 +50,21 @@ class User(UserMixin, db.Model):
         backref=db.backref("user", lazy=True),
         lazy=True,
     )
+    security_positions = db.relationship(
+        "SecurityHolding",
+        backref=db.backref("user", lazy=True),
+        lazy=True,
+    )
+    option_positions = db.relationship(
+        "OptionHolding",
+        backref=db.backref("user", lazy=True),
+        lazy=True,
+    )
+    future_positions = db.relationship(
+        "FutureHolding",
+        backref=db.backref("user", lazy=True),
+        lazy=True,
+    )
 
     def get_id(self):
         return str(self.id)
@@ -102,6 +117,112 @@ class PriceHistory(db.Model):
     product_id = db.Column(db.Integer, db.ForeignKey("product.id"), nullable=False)
     price = db.Column(db.Float, nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Security(db.Model):
+    symbol = db.Column(db.String(8), primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    last_price = db.Column(db.Float, nullable=False)
+    drift = db.Column(db.Float, nullable=False)
+    volatility = db.Column(db.Float, nullable=False)
+    mean_reversion = db.Column(db.Float, nullable=False)
+    fundamental_value = db.Column(db.Float, nullable=False)
+    liquidity = db.Column(db.Float, nullable=False)
+    impact = db.Column(db.Float, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    price_history = db.relationship("SecurityPriceHistory", backref="security", lazy=True)
+
+    __table_args__ = (
+        CheckConstraint("last_price > 0"),
+        CheckConstraint("volatility >= 0"),
+        CheckConstraint("liquidity > 0"),
+    )
+
+
+class SecurityPriceHistory(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    security_symbol = db.Column(db.String(8), db.ForeignKey("security.symbol"), nullable=False)
+    price = db.Column(db.Float, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SecurityHolding(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    security_symbol = db.Column(db.String(8), db.ForeignKey("security.symbol"), nullable=False)
+    quantity = db.Column(db.Float, nullable=False, default=0.0)
+    average_price = db.Column(db.Float, nullable=False, default=0.0)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    security = db.relationship("Security", lazy=True)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "security_symbol", name="uq_security_holding"),
+    )
+
+
+class OptionType(str, Enum):
+    CALL = "call"
+    PUT = "put"
+
+
+class OptionListing(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    security_symbol = db.Column(db.String(8), db.ForeignKey("security.symbol"), nullable=False)
+    option_type = db.Column(SqlEnum(OptionType), nullable=False)
+    strike = db.Column(db.Float, nullable=False)
+    expiration = db.Column(db.DateTime, nullable=False)
+    style = db.Column(db.String(32), nullable=False, default="european")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    security = db.relationship("Security", lazy=True)
+
+    __table_args__ = (CheckConstraint("strike > 0"),)
+
+
+class OptionHolding(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    listing_id = db.Column(db.Integer, db.ForeignKey("option_listing.id"), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False, default=0)
+    average_premium = db.Column(db.Float, nullable=False, default=0.0)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    listing = db.relationship("OptionListing", lazy=True)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "listing_id", name="uq_option_holding"),
+    )
+
+
+class FutureListing(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    security_symbol = db.Column(db.String(8), db.ForeignKey("security.symbol"), nullable=False)
+    delivery_date = db.Column(db.DateTime, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    security = db.relationship("Security", lazy=True)
+
+    __table_args__ = (
+        CheckConstraint("delivery_date > created_at"),
+    )
+
+
+class FutureHolding(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    listing_id = db.Column(db.Integer, db.ForeignKey("future_listing.id"), nullable=False)
+    quantity = db.Column(db.Integer, nullable=False, default=0)
+    entry_price = db.Column(db.Float, nullable=False, default=0.0)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    listing = db.relationship("FutureListing", lazy=True)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "listing_id", name="uq_future_holding"),
+    )
 
 
 class QueueEntry(db.Model):

--- a/app/routes.py
+++ b/app/routes.py
@@ -17,13 +17,27 @@ from flask_login import current_user, login_required
 
 from . import db
 from .models import (
+    FutureHolding,
+    FutureListing,
+    OptionHolding,
+    OptionListing,
+    OptionType,
     PriceHistory,
     PrisonersMatch,
     Product,
     QueueEntry,
     Role,
+    Security,
+    SecurityHolding,
+    SecurityPriceHistory,
     Transaction,
     User,
+)
+from .securities import (
+    execute_equity_trade,
+    execute_future_trade,
+    execute_option_trade,
+    get_simulator,
 )
 
 
@@ -73,6 +87,184 @@ def dashboard():
         transactions=latest_transactions,
         active_match=active_match,
     )
+
+
+@bp.route("/securities")
+@login_required
+def securities_hub():
+    simulator = get_simulator()
+    securities = Security.query.order_by(Security.symbol.asc()).all()
+    security_positions = {
+        holding.security_symbol: holding
+        for holding in SecurityHolding.query.filter_by(user_id=current_user.id).all()
+    }
+    option_positions = {
+        holding.listing_id: holding
+        for holding in OptionHolding.query.filter_by(user_id=current_user.id).all()
+    }
+    future_positions = {
+        holding.listing_id: holding
+        for holding in FutureHolding.query.filter_by(user_id=current_user.id).all()
+    }
+
+    active_options = (
+        OptionListing.query.filter(OptionListing.expiration > datetime.utcnow())
+        .order_by(OptionListing.security_symbol.asc(), OptionListing.expiration.asc())
+        .all()
+    )
+    option_quotes = [
+        {
+            "listing": listing,
+            "premium": simulator.price_option(listing),
+            "holding": option_positions.get(listing.id),
+        }
+        for listing in active_options
+    ]
+
+    active_futures = (
+        FutureListing.query.filter(FutureListing.delivery_date > datetime.utcnow())
+        .order_by(FutureListing.security_symbol.asc(), FutureListing.delivery_date.asc())
+        .all()
+    )
+    future_quotes = [
+        {
+            "listing": listing,
+            "forward": simulator.price_future(listing),
+            "holding": future_positions.get(listing.id),
+        }
+        for listing in active_futures
+    ]
+
+    return render_template(
+        "securities.html",
+        securities=securities,
+        security_positions=security_positions,
+        option_quotes=option_quotes,
+        future_quotes=future_quotes,
+        update_interval=simulator.interval,
+        risk_free_rate=simulator.risk_free_rate,
+    )
+
+
+@bp.route("/api/securities")
+@login_required
+def securities_snapshot():
+    securities = Security.query.order_by(Security.symbol.asc()).all()
+    payload = []
+    for security in securities:
+        latest_history = (
+            SecurityPriceHistory.query.filter_by(security_symbol=security.symbol)
+            .order_by(SecurityPriceHistory.timestamp.desc())
+            .limit(2)
+            .all()
+        )
+        change = 0.0
+        if len(latest_history) >= 2:
+            change = latest_history[0].price - latest_history[1].price
+        payload.append(
+            {
+                "symbol": security.symbol,
+                "name": security.name,
+                "price": security.last_price,
+                "updated_at": security.updated_at.isoformat(),
+                "description": security.description,
+                "change": change,
+            }
+        )
+    return jsonify(payload)
+
+
+@bp.route("/securities/trade", methods=["POST"])
+@login_required
+def trade_security():
+    symbol = request.form.get("symbol")
+    side = request.form.get("side")
+    quantity = request.form.get("quantity", type=float)
+    if not symbol or not quantity or side not in {"buy", "sell"}:
+        flash("Please choose a security and quantity.", "error")
+        return redirect(url_for("main.securities_hub"))
+    quantity = abs(quantity)
+    signed_quantity = quantity if side == "buy" else -quantity
+    try:
+        result = execute_equity_trade(current_user, symbol, signed_quantity)
+        amount = result.cash_delta
+        record_transaction(
+            current_user,
+            amount,
+            result.description,
+            type_="securities",
+            commit=False,
+        )
+        db.session.commit()
+        flash(f"{result.description} at {result.price:.2f}.", "success")
+    except ValueError as exc:
+        db.session.rollback()
+        flash(str(exc), "error")
+    return redirect(url_for("main.securities_hub"))
+
+
+@bp.route("/securities/options/trade", methods=["POST"])
+@login_required
+def trade_option():
+    listing_id = request.form.get("listing_id", type=int)
+    side = request.form.get("side")
+    quantity = request.form.get("quantity", type=int)
+    if not listing_id or not quantity or side not in {"buy", "sell"}:
+        flash("Select an option and quantity.", "error")
+        return redirect(url_for("main.securities_hub"))
+    quantity = abs(quantity)
+    signed_quantity = quantity if side == "buy" else -quantity
+    try:
+        result = execute_option_trade(current_user, listing_id, signed_quantity)
+        amount = result.cash_delta
+        record_transaction(
+            current_user,
+            amount,
+            result.description,
+            type_="options",
+            commit=False,
+        )
+        db.session.commit()
+        flash(f"{result.description} for {result.price:.2f} premium.", "success")
+    except ValueError as exc:
+        db.session.rollback()
+        flash(str(exc), "error")
+    return redirect(url_for("main.securities_hub"))
+
+
+@bp.route("/securities/futures/trade", methods=["POST"])
+@login_required
+def trade_future():
+    listing_id = request.form.get("listing_id", type=int)
+    side = request.form.get("side")
+    quantity = request.form.get("quantity", type=int)
+    if not listing_id or not quantity or side not in {"long", "short"}:
+        flash("Select a future and quantity.", "error")
+        return redirect(url_for("main.securities_hub"))
+    quantity = abs(quantity)
+    signed_quantity = quantity if side == "long" else -quantity
+    try:
+        result = execute_future_trade(current_user, listing_id, signed_quantity)
+        amount = result.cash_delta
+        record_transaction(
+            current_user,
+            amount,
+            result.description,
+            type_="futures",
+            commit=False,
+        )
+        db.session.commit()
+        if result.cash_delta < 0:
+            message = f"{result.description}. Margin posted {abs(result.cash_delta):.2f}."
+        elif result.cash_delta > 0:
+            message = f"{result.description}. Margin released {result.cash_delta:.2f}."
+        else:
+            message = f"{result.description}."
+        flash(message, "success")
+    except ValueError as exc:
+        db.session.rollback()
+        flash(str(exc), "error")
+    return redirect(url_for("main.securities_hub"))
 
 
 @bp.route("/single-player", methods=["GET", "POST"])

--- a/app/securities.py
+++ b/app/securities.py
@@ -1,0 +1,510 @@
+"""Market simulation, pricing, and trading utilities for the arcade securities desk."""
+from __future__ import annotations
+
+import math
+import random
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from flask import current_app, has_app_context
+
+from . import db
+from .models import (
+    FutureHolding,
+    FutureListing,
+    OptionHolding,
+    OptionListing,
+    OptionType,
+    Security,
+    SecurityHolding,
+    SecurityPriceHistory,
+)
+
+SECONDS_IN_YEAR = 365 * 24 * 60 * 60
+MIN_PRICE = 0.01
+
+
+@dataclass
+class SecurityConfig:
+    symbol: str
+    name: str
+    description: str
+    initial_price: float
+    drift: float
+    volatility: float
+    mean_reversion: float
+    fundamental_value: float
+    liquidity: float
+    impact: float
+    options_tenors: List[int]
+    options_strike_multipliers: List[float]
+    futures_tenors: List[int]
+
+
+@dataclass
+class TradeResult:
+    symbol: str
+    quantity: float
+    price: float
+    notional: float
+    action: str
+    description: str
+    cash_delta: float
+
+
+class MarketSimulator:
+    """Controls stochastic price evolution and derivative listings."""
+
+    def __init__(self, app, config_path: Path):
+        self.app = app
+        self.config_path = config_path
+        self.interval = 5.0
+        self.risk_free_rate = 0.01
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self.configs: Dict[str, SecurityConfig] = {}
+        self.reload_config()
+
+    # ------------------------------------------------------------------
+    # Configuration loading
+    def reload_config(self) -> None:
+        raw = _load_toml(self.config_path)
+        market_cfg = raw.get("market", {})
+        self.interval = float(market_cfg.get("update_interval_seconds", 5))
+        risk_cfg = raw.get("risk", {})
+        self.risk_free_rate = float(risk_cfg.get("risk_free_rate", 0.01))
+
+        securities_cfg = raw.get("securities", {})
+        configs: Dict[str, SecurityConfig] = {}
+        for symbol, payload in securities_cfg.items():
+            configs[symbol] = SecurityConfig(
+                symbol=symbol,
+                name=str(payload.get("name", symbol)),
+                description=str(payload.get("description", "")),
+                initial_price=float(payload.get("initial_price", 100.0)),
+                drift=float(payload.get("drift", 0.0)),
+                volatility=max(0.0, float(payload.get("volatility", 0.2))),
+                mean_reversion=float(payload.get("mean_reversion", 0.0)),
+                fundamental_value=float(payload.get("fundamental_value", 100.0)),
+                liquidity=max(1e-6, float(payload.get("liquidity", 1.0))),
+                impact=max(0.0, float(payload.get("impact", 0.01))),
+                options_tenors=[int(x) for x in payload.get("options_tenors", [7, 30])],
+                options_strike_multipliers=[
+                    float(x) for x in payload.get("options_strike_multipliers", [0.9, 1.0, 1.1])
+                ],
+                futures_tenors=[int(x) for x in payload.get("futures_tenors", [30])],
+            )
+        self.configs = configs
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    def ensure_initialized(self) -> None:
+        with self.app.app_context():
+            db.create_all()
+            now = datetime.utcnow()
+            for symbol, config in self.configs.items():
+                security = Security.query.get(symbol)
+                if not security:
+                    security = Security(
+                        symbol=symbol,
+                        name=config.name,
+                        description=config.description,
+                        last_price=config.initial_price,
+                        drift=config.drift,
+                        volatility=config.volatility,
+                        mean_reversion=config.mean_reversion,
+                        fundamental_value=config.fundamental_value,
+                        liquidity=config.liquidity,
+                        impact=config.impact,
+                        updated_at=now,
+                    )
+                    db.session.add(security)
+                    db.session.add(
+                        SecurityPriceHistory(
+                            security_symbol=symbol, price=config.initial_price, timestamp=now
+                        )
+                    )
+                else:
+                    security.name = config.name
+                    security.description = config.description
+                    security.drift = config.drift
+                    security.volatility = config.volatility
+                    security.mean_reversion = config.mean_reversion
+                    security.fundamental_value = config.fundamental_value
+                    security.liquidity = config.liquidity
+                    security.impact = config.impact
+                    if security.last_price <= 0:
+                        security.last_price = config.initial_price
+                        db.session.add(
+                            SecurityPriceHistory(
+                                security_symbol=symbol,
+                                price=config.initial_price,
+                                timestamp=now,
+                            )
+                        )
+                self._ensure_option_listings(security, config, now)
+                self._ensure_future_listings(security, config, now)
+            db.session.commit()
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name="market-simulator", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1)
+
+    # ------------------------------------------------------------------
+    def _run(self) -> None:
+        with self.app.app_context():
+            while not self._stop.is_set():
+                start = time.monotonic()
+                self.step()
+                elapsed = time.monotonic() - start
+                delay = max(0.0, self.interval - elapsed)
+                time.sleep(delay)
+
+    def step(self) -> None:
+        with self._lock:
+            now = datetime.utcnow()
+            for symbol, config in self.configs.items():
+                security = Security.query.get(symbol)
+                if not security:
+                    continue
+                price = max(MIN_PRICE, security.last_price)
+                dt = max(self.interval, 1.0) / SECONDS_IN_YEAR
+                mean_reversion_term = config.mean_reversion * (config.fundamental_value - price) / max(price, 1e-6)
+                drift = config.drift + mean_reversion_term
+                sigma = max(0.0, config.volatility)
+                shock = random.gauss(0.0, 1.0)
+                exponent = (drift - 0.5 * sigma * sigma) * dt + sigma * math.sqrt(dt) * shock
+                new_price = max(MIN_PRICE, price * math.exp(exponent))
+                security.last_price = new_price
+                security.updated_at = now
+                db.session.add(
+                    SecurityPriceHistory(security_symbol=symbol, price=new_price, timestamp=now)
+                )
+            db.session.commit()
+
+    # ------------------------------------------------------------------
+    def price_option(self, listing: OptionListing) -> float:
+        security = listing.security
+        if not security:
+            return 0.0
+        spot = max(MIN_PRICE, security.last_price)
+        strike = listing.strike
+        time_to_expiry = max(0.0, (listing.expiration - datetime.utcnow()).total_seconds()) / SECONDS_IN_YEAR
+        if time_to_expiry <= 0:
+            if listing.option_type is OptionType.CALL:
+                return max(0.0, spot - strike)
+            return max(0.0, strike - spot)
+        sigma = max(MIN_PRICE, security.volatility)
+        rate = self.risk_free_rate
+        return _black_scholes(spot, strike, time_to_expiry, rate, sigma, listing.option_type)
+
+    def price_future(self, listing: FutureListing) -> float:
+        security = listing.security
+        if not security:
+            return 0.0
+        spot = max(MIN_PRICE, security.last_price)
+        time_to_delivery = max(
+            0.0, (listing.delivery_date - datetime.utcnow()).total_seconds() / SECONDS_IN_YEAR
+        )
+        rate = self.risk_free_rate
+        return spot * math.exp(rate * time_to_delivery)
+
+    def apply_order_impact(self, symbol: str, signed_quantity: float) -> None:
+        if signed_quantity == 0:
+            return
+        config = self.configs.get(symbol)
+        if not config:
+            return
+        ctx = None
+        if not has_app_context():
+            ctx = self.app.app_context()
+            ctx.push()
+        try:
+            security = Security.query.get(symbol)
+            if not security:
+                return
+            adjustment = 1.0 + config.impact * signed_quantity / max(config.liquidity, 1e-6)
+            adjustment = max(0.5, min(1.5, adjustment))
+            new_price = max(MIN_PRICE, security.last_price * adjustment)
+            now = datetime.utcnow()
+            security.last_price = new_price
+            security.updated_at = now
+            db.session.add(
+                SecurityPriceHistory(security_symbol=symbol, price=new_price, timestamp=now)
+            )
+            db.session.flush()
+        finally:
+            if ctx is not None:
+                ctx.pop()
+
+    # ------------------------------------------------------------------
+    def _ensure_option_listings(self, security: Security, config: SecurityConfig, now: datetime) -> None:
+        base_price = max(MIN_PRICE, security.last_price or config.initial_price)
+        for tenor in config.options_tenors:
+            expiration = (now + timedelta(days=tenor)).replace(second=0, microsecond=0)
+            for multiplier in config.options_strike_multipliers:
+                strike = round(base_price * multiplier, 2)
+                for option_type in (OptionType.CALL, OptionType.PUT):
+                    existing = OptionListing.query.filter_by(
+                        security_symbol=security.symbol,
+                        option_type=option_type,
+                        strike=strike,
+                        expiration=expiration,
+                    ).first()
+                    if not existing:
+                        db.session.add(
+                            OptionListing(
+                                security_symbol=security.symbol,
+                                option_type=option_type,
+                                strike=strike,
+                                expiration=expiration,
+                            )
+                        )
+
+    def _ensure_future_listings(self, security: Security, config: SecurityConfig, now: datetime) -> None:
+        for tenor in config.futures_tenors:
+            delivery_date = (now + timedelta(days=tenor)).replace(second=0, microsecond=0)
+            existing = FutureListing.query.filter_by(
+                security_symbol=security.symbol, delivery_date=delivery_date
+            ).first()
+            if not existing:
+                db.session.add(
+                    FutureListing(security_symbol=security.symbol, delivery_date=delivery_date)
+                )
+
+
+# ----------------------------------------------------------------------
+# Trading helpers
+
+def execute_equity_trade(user, symbol: str, quantity: float) -> TradeResult:
+    if quantity == 0:
+        raise ValueError("Quantity must be non-zero.")
+    security = Security.query.get(symbol)
+    if not security:
+        raise ValueError("Security not found.")
+    quantity = float(quantity)
+    price = max(MIN_PRICE, security.last_price)
+    notional = price * abs(quantity)
+    holding = SecurityHolding.query.filter_by(user_id=user.id, security_symbol=symbol).first()
+    if quantity > 0:
+        if user.balance < notional:
+            raise ValueError("Insufficient balance to buy.")
+        if not holding:
+            holding = SecurityHolding(user_id=user.id, security_symbol=symbol)
+        new_qty = holding.quantity + quantity
+        total_cost = holding.quantity * holding.average_price + notional
+        holding.quantity = new_qty
+        holding.average_price = total_cost / new_qty if new_qty else 0.0
+    else:
+        if not holding or holding.quantity < abs(quantity):
+            raise ValueError("Not enough shares to sell.")
+        new_qty = holding.quantity + quantity
+        holding.quantity = new_qty
+        if new_qty <= 0:
+            holding.quantity = 0.0
+            holding.average_price = 0.0
+    holding.updated_at = datetime.utcnow()
+    db.session.add(holding)
+    liquidity_scale = max(security.liquidity, 1.0)
+    current_app.market_simulator.apply_order_impact(symbol, quantity / liquidity_scale)
+    return TradeResult(
+        symbol=symbol,
+        quantity=quantity,
+        price=price,
+        notional=notional,
+        action="buy" if quantity > 0 else "sell",
+        description=("Bought" if quantity > 0 else "Sold") + f" {abs(quantity):.2f} {symbol}",
+        cash_delta=-notional if quantity > 0 else notional,
+    )
+
+
+def execute_option_trade(user, listing_id: int, quantity: int) -> TradeResult:
+    if quantity == 0:
+        raise ValueError("Quantity must be non-zero.")
+    listing = OptionListing.query.get(listing_id)
+    if not listing:
+        raise ValueError("Option listing not found.")
+    simulator: MarketSimulator = current_app.market_simulator
+    premium = simulator.price_option(listing)
+    notional = premium * abs(quantity)
+    holding = OptionHolding.query.filter_by(user_id=user.id, listing_id=listing_id).first()
+    if quantity > 0:
+        if user.balance < notional:
+            raise ValueError("Insufficient balance to buy option.")
+        if not holding:
+            holding = OptionHolding(user_id=user.id, listing_id=listing_id)
+        new_qty = holding.quantity + quantity
+        total_premium = holding.quantity * holding.average_premium + notional
+        holding.quantity = new_qty
+        holding.average_premium = total_premium / new_qty if new_qty else 0.0
+    else:
+        if not holding or holding.quantity < abs(quantity):
+            raise ValueError("Not enough contracts to sell.")
+        holding.quantity += quantity
+        if holding.quantity <= 0:
+            holding.quantity = 0
+            holding.average_premium = 0.0
+    holding.updated_at = datetime.utcnow()
+    db.session.add(holding)
+    option_delta_sign = 1 if listing.option_type is OptionType.CALL else -1
+    signed_pressure = option_delta_sign * quantity
+    current_app.market_simulator.apply_order_impact(
+        listing.security_symbol, signed_pressure * 0.05
+    )
+    action = "buy" if quantity > 0 else "sell"
+    kind = "call" if listing.option_type is OptionType.CALL else "put"
+    description = f"{action.title()} {abs(quantity)} {kind.upper()} {listing.security_symbol} @{listing.strike:.2f}"
+    return TradeResult(
+        symbol=listing.security_symbol,
+        quantity=float(quantity),
+        price=premium,
+        notional=notional,
+        action=action,
+        description=description,
+        cash_delta=-notional if quantity > 0 else notional,
+    )
+
+
+def execute_future_trade(user, listing_id: int, quantity: int) -> TradeResult:
+    if quantity == 0:
+        raise ValueError("Quantity must be non-zero.")
+    listing = FutureListing.query.get(listing_id)
+    if not listing:
+        raise ValueError("Future listing not found.")
+    simulator: MarketSimulator = current_app.market_simulator
+    forward_price = simulator.price_future(listing)
+    holding = FutureHolding.query.filter_by(user_id=user.id, listing_id=listing_id).first()
+    previous_qty = holding.quantity if holding else 0
+    new_qty = previous_qty + quantity
+    prev_margin = forward_price * abs(previous_qty) * 0.1
+    new_margin = forward_price * abs(new_qty) * 0.1
+    margin_delta = new_margin - prev_margin
+    if margin_delta > 0 and user.balance < margin_delta:
+        raise ValueError("Insufficient balance for margin.")
+    if not holding:
+        holding = FutureHolding(user_id=user.id, listing_id=listing_id)
+    holding.quantity = new_qty
+    holding.entry_price = forward_price if new_qty else 0.0
+    holding.updated_at = datetime.utcnow()
+    db.session.add(holding)
+    current_app.market_simulator.apply_order_impact(listing.security_symbol, quantity * 0.1)
+    action = "long" if new_qty > 0 else "short" if new_qty < 0 else "flat"
+    description = (
+        f"Adjusted future position on {listing.security_symbol} by {int(quantity):+d} contract(s)"
+    )
+    return TradeResult(
+        symbol=listing.security_symbol,
+        quantity=float(quantity),
+        price=forward_price,
+        notional=abs(margin_delta),
+        action=action,
+        description=description,
+        cash_delta=-margin_delta,
+    )
+
+
+# ----------------------------------------------------------------------
+# Pricing utilities
+
+def _black_scholes(spot: float, strike: float, time_to_expiry: float, rate: float, sigma: float, option_type: OptionType) -> float:
+    if spot <= 0 or strike <= 0 or time_to_expiry <= 0 or sigma <= 0:
+        if option_type is OptionType.CALL:
+            return max(0.0, spot - strike)
+        return max(0.0, strike - spot)
+    sqrt_t = math.sqrt(time_to_expiry)
+    d1 = (math.log(spot / strike) + (rate + 0.5 * sigma * sigma) * time_to_expiry) / (sigma * sqrt_t)
+    d2 = d1 - sigma * sqrt_t
+    if option_type is OptionType.CALL:
+        return spot * _norm_cdf(d1) - strike * math.exp(-rate * time_to_expiry) * _norm_cdf(d2)
+    else:
+        return strike * math.exp(-rate * time_to_expiry) * _norm_cdf(-d2) - spot * _norm_cdf(-d1)
+
+
+def _norm_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+# ----------------------------------------------------------------------
+# Minimal TOML loader (sufficient for the project configuration)
+
+def _load_toml(path: Path) -> dict:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing securities configuration at {path}")
+    data: dict = {}
+    current_stack: List[str] = []
+    current_section = data
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section_path = line[1:-1].strip()
+            if not section_path:
+                raise ValueError("Empty section in TOML file.")
+            current_stack = section_path.split(".")
+            current_section = data
+            for part in current_stack:
+                current_section = current_section.setdefault(part, {})
+            continue
+        if "=" not in line:
+            raise ValueError(f"Invalid line in TOML: {raw_line}")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        current_section[key] = _parse_toml_value(value)
+    return data
+
+
+def _parse_toml_value(value: str):
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        parts = [part.strip() for part in inner.split(",")]
+        return [_parse_toml_value(part) for part in parts]
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    if "." in value or "e" in value.lower():
+        try:
+            return float(value)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unable to parse float from '{value}'") from exc
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+# ----------------------------------------------------------------------
+# Application helper
+
+def init_market(app) -> MarketSimulator:
+    config_path = Path(app.root_path) / "config" / "securities.toml"
+    simulator = MarketSimulator(app, config_path)
+    simulator.ensure_initialized()
+
+    @app.before_first_request
+    def _start_market_thread() -> None:  # pragma: no cover - background thread
+        simulator.start()
+
+    app.market_simulator = simulator
+    return simulator
+
+
+def get_simulator() -> MarketSimulator:
+    return current_app.market_simulator

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -134,6 +134,10 @@ button.danger:hover {
   box-shadow: inset 0 0 0 2px rgba(26, 255, 213, 0.08);
 }
 
+.panel.wide {
+  grid-column: 1 / -1;
+}
+
 .grid {
   display: grid;
   gap: 1.5rem;
@@ -157,6 +161,85 @@ button.danger:hover {
 
 .list li:last-child {
   border-bottom: none;
+}
+
+.quotes {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.quotes th,
+.quotes td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.quotes tbody tr:hover {
+  background: rgba(26, 255, 213, 0.05);
+}
+
+.quotes.compact th,
+.quotes.compact td {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.trade-form {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.trade-form input[type="number"] {
+  width: 4.5rem;
+  padding: 0.3rem 0.4rem;
+  background: #0f161d;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: var(--text);
+  border-radius: 4px;
+}
+
+.trade-form button {
+  padding: 0.35rem 0.7rem;
+  font-size: 0.75rem;
+}
+
+.mono {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.03em;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.change.positive,
+.amount.positive {
+  color: var(--accent);
+}
+
+.change.negative,
+.amount.negative {
+  color: var(--danger);
+}
+
+.description {
+  max-width: 240px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .amount.positive {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,6 +19,7 @@
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
           <a href="{{ url_for('main.single_player') }}">Solo Game</a>
           <a href="{{ url_for('main.prisoners_dilemma') }}">Prisoner's Dilemma</a>
+          <a href="{{ url_for('main.securities_hub') }}">Securities</a>
           {% if current_user.is_merchant %}
             <a href="{{ url_for('main.merchant_portal') }}">Merchant</a>
           {% endif %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -10,6 +10,7 @@
     <div class="actions">
       <a class="button" href="{{ url_for('main.single_player') }}">Play solo game</a>
       <a class="button" href="{{ url_for('main.prisoners_dilemma') }}">Enter Prisoner's Dilemma</a>
+      <a class="button" href="{{ url_for('main.securities_hub') }}">Visit Securities Desk</a>
       {% if current_user.is_merchant %}
         <a class="button" href="{{ url_for('main.merchant_portal') }}">Open Merchant Portal</a>
       {% endif %}

--- a/app/templates/securities.html
+++ b/app/templates/securities.html
@@ -1,0 +1,177 @@
+{% extends 'base.html' %}
+{% block title %}Securities Desk{% endblock %}
+{% block content %}
+<section class="grid securities-grid">
+  <article class="panel wide">
+    <h2>Primary Securities</h2>
+    <p class="muted">Prices evolve every {{ update_interval|int }} seconds based on stochastic supply and demand dynamics.</p>
+    <table class="quotes" id="securities-quotes">
+      <thead>
+        <tr>
+          <th>Symbol</th>
+          <th>Name</th>
+          <th>Last Price</th>
+          <th>Δ</th>
+          <th>Position</th>
+          <th>Description</th>
+          <th>Trade</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for security in securities %}
+          {% set position = security_positions.get(security.symbol) %}
+          <tr data-symbol="{{ security.symbol }}">
+            <td class="mono">{{ security.symbol }}</td>
+            <td>{{ security.name }}</td>
+            <td class="mono price">{{ '%.2f'|format(security.last_price) }}</td>
+            <td class="mono change">0.00</td>
+            <td>
+              {% if position and position.quantity %}
+                {{ '%.2f'|format(position.quantity) }} @ {{ '%.2f'|format(position.average_price) }}
+              {% else %}
+                —
+              {% endif %}
+            </td>
+            <td class="description">{{ security.description }}</td>
+            <td>
+              <form method="post" action="{{ url_for('main.trade_security') }}" class="trade-form">
+                <input type="hidden" name="symbol" value="{{ security.symbol }}">
+                <label class="sr-only" for="qty-{{ loop.index }}">Quantity</label>
+                <input id="qty-{{ loop.index }}" name="quantity" type="number" min="0.1" step="0.1" value="1" required>
+                <button type="submit" name="side" value="buy">Buy</button>
+                <button type="submit" name="side" value="sell">Sell</button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </article>
+
+  <article class="panel">
+    <h3>European Options</h3>
+    <p class="muted">Premiums computed via Black–Scholes with a risk-free rate of {{ '%.2f'|format(risk_free_rate * 100) }}%.</p>
+    <table class="quotes compact">
+      <thead>
+        <tr>
+          <th>Contract</th>
+          <th>Expiry</th>
+          <th>Strike</th>
+          <th>Premium</th>
+          <th>Your Position</th>
+          <th>Trade</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for quote in option_quotes %}
+          {% set listing = quote.listing %}
+          {% set holding = quote.holding %}
+          <tr>
+            <td class="mono">{{ listing.security_symbol }} {{ listing.option_type.value|upper }}</td>
+            <td>{{ listing.expiration.strftime('%Y-%m-%d') }}</td>
+            <td class="mono">{{ '%.2f'|format(listing.strike) }}</td>
+            <td class="mono">{{ '%.2f'|format(quote.premium) }}</td>
+            <td>
+              {% if holding and holding.quantity %}
+                {{ holding.quantity }} @ {{ '%.2f'|format(holding.average_premium) }}
+              {% else %}
+                —
+              {% endif %}
+            </td>
+            <td>
+              <form method="post" action="{{ url_for('main.trade_option') }}" class="trade-form">
+                <input type="hidden" name="listing_id" value="{{ listing.id }}">
+                <input name="quantity" type="number" min="1" step="1" value="1" required>
+                <button type="submit" name="side" value="buy">Buy</button>
+                <button type="submit" name="side" value="sell">Sell</button>
+              </form>
+            </td>
+          </tr>
+        {% else %}
+          <tr><td colspan="6">No option listings available.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </article>
+
+  <article class="panel">
+    <h3>Forward Futures</h3>
+    <p class="muted">Quoted on a cost-of-carry model; a 10% margin is posted or released with each adjustment.</p>
+    <table class="quotes compact">
+      <thead>
+        <tr>
+          <th>Contract</th>
+          <th>Delivery</th>
+          <th>Forward</th>
+          <th>Your Position</th>
+          <th>Adjust</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for quote in future_quotes %}
+          {% set listing = quote.listing %}
+          {% set holding = quote.holding %}
+          <tr>
+            <td class="mono">{{ listing.security_symbol }} FUT</td>
+            <td>{{ listing.delivery_date.strftime('%Y-%m-%d') }}</td>
+            <td class="mono">{{ '%.2f'|format(quote.forward) }}</td>
+            <td>
+              {% if holding and holding.quantity %}
+                {{ holding.quantity }} @ {{ '%.2f'|format(holding.entry_price) }}
+              {% else %}
+                —
+              {% endif %}
+            </td>
+            <td>
+              <form method="post" action="{{ url_for('main.trade_future') }}" class="trade-form">
+                <input type="hidden" name="listing_id" value="{{ listing.id }}">
+                <input name="quantity" type="number" min="1" step="1" value="1" required>
+                <button type="submit" name="side" value="long">Long</button>
+                <button type="submit" name="side" value="short">Short</button>
+              </form>
+            </td>
+          </tr>
+        {% else %}
+          <tr><td colspan="5">No futures available.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </article>
+</section>
+
+<script>
+  const refreshInterval = Math.max(1000, {{ update_interval|int }} * 1000);
+  async function refreshQuotes() {
+    try {
+      const response = await fetch("{{ url_for('main.securities_snapshot') }}", {cache: 'no-cache'});
+      if (!response.ok) {
+        return;
+      }
+      const data = await response.json();
+      data.forEach(entry => {
+        const row = document.querySelector(`#securities-quotes tbody tr[data-symbol="${entry.symbol}"]`);
+        if (!row) {
+          return;
+        }
+        const priceCell = row.querySelector('.price');
+        const changeCell = row.querySelector('.change');
+        if (priceCell) {
+          priceCell.textContent = entry.price.toFixed(2);
+        }
+        if (changeCell) {
+          const delta = entry.change || 0;
+          changeCell.textContent = delta.toFixed(2);
+          changeCell.classList.toggle('positive', delta > 0);
+          changeCell.classList.toggle('negative', delta < 0);
+        }
+      });
+    } catch (err) {
+      console.error('Failed to refresh quotes', err);
+    }
+  }
+  document.addEventListener('DOMContentLoaded', () => {
+    refreshQuotes();
+    setInterval(refreshQuotes, refreshInterval);
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a market simulator that seeds securities from TOML config, maintains prices, and generates option/future listings
- extend the data model and routes to support trading equities, options, and futures with proper accounting
- build a dedicated securities desk UI with live quote polling and refreshed styling

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d0b4bc67348332885e460ff0880c5e