### PR TITLE
Add player transfers, requests, and dashboard QR code

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -99,6 +99,20 @@ class Transaction(db.Model):
     counterparty = db.relationship("User", foreign_keys=[counterparty_id], lazy=True)
 
 
+class MoneyRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    requester_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    target_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    message = db.Column(db.String(255), nullable=True)
+    status = db.Column(db.String(20), nullable=False, default="pending")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    resolved_at = db.Column(db.DateTime, nullable=True)
+
+    requester = db.relationship("User", foreign_keys=[requester_id], lazy=True)
+    target = db.relationship("User", foreign_keys=[target_id], lazy=True)
+
+
 class Product(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False)

--- a/app/routes.py
+++ b/app/routes.py
@@ -33,6 +33,7 @@ from .models import (
     Transaction,
     User,
     AppSetting,
+    MoneyRequest,
 )
 from .securities import (
     execute_equity_trade,
@@ -43,6 +44,21 @@ from .securities import (
 
 
 bp = Blueprint("main", __name__)
+
+
+def find_user_by_handle(handle: str):
+    if not handle:
+        return None
+    normalized = handle.strip().lower()
+    if not normalized:
+        return None
+    matches = User.query.filter(User.email.ilike(f"{normalized}@%"))
+    users = matches.all()
+    if not users:
+        return None
+    if len(users) > 1:
+        raise ValueError("multiple")
+    return users[0]
 
 
 def record_transaction(user, amount, description, counterparty=None, type_="game", commit=True):
@@ -93,12 +109,148 @@ def dashboard():
         .order_by(PrisonersMatch.created_at.desc())
         .first()
     )
+    target_handle = request.args.get("target", "").strip()
+    incoming_requests = (
+        MoneyRequest.query.filter_by(target_id=current_user.id, status="pending")
+        .order_by(MoneyRequest.created_at.desc())
+        .all()
+    )
+    outgoing_requests = (
+        MoneyRequest.query.filter_by(requester_id=current_user.id)
+        .order_by(MoneyRequest.created_at.desc())
+        .limit(10)
+        .all()
+    )
     return render_template(
         "dashboard.html",
         balance=current_user.balance,
         transactions=latest_transactions,
         active_match=active_match,
+        target_handle=target_handle,
+        incoming_requests=incoming_requests,
+        outgoing_requests=outgoing_requests,
+        qr_data_uri=build_qr_for_user(current_user),
     )
+
+
+@bp.route("/transfer", methods=["POST"])
+@login_required
+def handle_transfer():
+    action = request.form.get("action")
+    handle = (request.form.get("handle") or "").strip()
+    amount = request.form.get("amount", type=float)
+    message = (request.form.get("message") or "").strip()
+    redirect_target = url_for("main.dashboard", target=handle) if handle else url_for("main.dashboard")
+
+    if not amount or amount <= 0:
+        flash("Please enter a positive amount.", "error")
+        return redirect(redirect_target)
+
+    try:
+        target_user = find_user_by_handle(handle)
+    except ValueError:
+        flash("Multiple users share that handle. Please use their full email instead.", "error")
+        return redirect(redirect_target)
+
+    if not target_user:
+        flash("Could not find a user with that handle.", "error")
+        return redirect(redirect_target)
+
+    if action == "send":
+        if target_user.id == current_user.id:
+            flash("You cannot send money to yourself.", "error")
+            return redirect(redirect_target)
+        if current_user.balance < amount:
+            flash("Insufficient balance to send that amount.", "error")
+            return redirect(redirect_target)
+
+        note = f" ({message})" if message else ""
+        record_transaction(
+            current_user,
+            -amount,
+            f"Transfer to {target_user.name}{note}",
+            counterparty=target_user,
+            type_="transfer",
+            commit=False,
+        )
+        record_transaction(
+            target_user,
+            amount,
+            f"Transfer from {current_user.name}{note}",
+            counterparty=current_user,
+            type_="transfer",
+            commit=False,
+        )
+        db.session.commit()
+        flash(f"Sent {amount:.2f} credits to {target_user.name}.", "success")
+        return redirect(url_for("main.dashboard"))
+
+    if action == "request":
+        if target_user.id == current_user.id:
+            flash("You cannot request money from yourself.", "error")
+            return redirect(redirect_target)
+        money_request = MoneyRequest(
+            requester=current_user,
+            target=target_user,
+            amount=amount,
+            message=message or None,
+        )
+        db.session.add(money_request)
+        db.session.commit()
+        flash(f"Requested {amount:.2f} credits from {target_user.name}.", "success")
+        return redirect(url_for("main.dashboard"))
+
+    flash("Unknown action.", "error")
+    return redirect(url_for("main.dashboard"))
+
+
+@bp.route("/requests/<int:request_id>/respond", methods=["POST"])
+@login_required
+def respond_money_request(request_id):
+    money_request = MoneyRequest.query.get_or_404(request_id)
+    if money_request.target_id != current_user.id:
+        abort(403)
+    if money_request.status != "pending":
+        flash("This request has already been handled.", "info")
+        return redirect(url_for("main.dashboard"))
+
+    action = request.form.get("action")
+    if action == "accept":
+        if current_user.balance < money_request.amount:
+            flash("You do not have enough balance to fulfill this request.", "error")
+            return redirect(url_for("main.dashboard"))
+        note = f" ({money_request.message})" if money_request.message else ""
+        record_transaction(
+            current_user,
+            -money_request.amount,
+            f"Money request from {money_request.requester.name}{note}",
+            counterparty=money_request.requester,
+            type_="transfer",
+            commit=False,
+        )
+        record_transaction(
+            money_request.requester,
+            money_request.amount,
+            f"Money request fulfilled by {current_user.name}{note}",
+            counterparty=current_user,
+            type_="transfer",
+            commit=False,
+        )
+        money_request.status = "completed"
+        money_request.resolved_at = datetime.utcnow()
+        db.session.commit()
+        flash(f"Sent {money_request.amount:.2f} credits to {money_request.requester.name}.", "success")
+        return redirect(url_for("main.dashboard"))
+
+    if action == "decline":
+        money_request.status = "declined"
+        money_request.resolved_at = datetime.utcnow()
+        db.session.commit()
+        flash("Request declined.", "info")
+        return redirect(url_for("main.dashboard"))
+
+    flash("Unknown action.", "error")
+    return redirect(url_for("main.dashboard"))
 
 
 @bp.route("/securities")
@@ -492,6 +644,19 @@ def update_price(product, new_price):
     db.session.add(PriceHistory(product=product, price=product.price))
     db.session.commit()
     flash("Price updated.", "success")
+
+
+def build_qr_for_user(user):
+    handle = user.email.split("@")[0]
+    target_url = url_for("main.dashboard", target=handle, _external=True)
+    qr = qrcode.QRCode(version=1, error_correction=qrcode.constants.ERROR_CORRECT_L)
+    qr.add_data(target_url)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    data = base64.b64encode(buf.getvalue()).decode("utf-8")
+    return f"data:image/png;base64,{data}"
 
 
 def build_qr_for_product(product, buyer_id):

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -294,6 +294,25 @@ button.danger:hover {
   margin-top: 0.4rem;
 }
 
+.form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  background: #0f161d;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  border-radius: 4px;
+  margin-top: 0.4rem;
+  min-height: 3.5rem;
+  resize: vertical;
+}
+
+.form .actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
 .inline-form {
   display: flex;
   gap: 0.5rem;
@@ -317,6 +336,61 @@ button.danger:hover {
   margin-top: 1rem;
   border: 4px solid rgba(26, 255, 213, 0.25);
   border-radius: 8px;
+}
+
+.qr-wrapper {
+  margin-top: 1.25rem;
+  text-align: center;
+}
+
+.qr-wrapper img {
+  width: 160px;
+  height: 160px;
+  border: 4px solid rgba(26, 255, 213, 0.25);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.6rem;
+}
+
+.qr-wrapper p {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-top: 0.5rem;
+}
+
+.request-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.request-item {
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.12);
+  padding-bottom: 0.75rem;
+}
+
+.request-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.request-item header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.request-item header span {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.request-item-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
 }
 
 .table {

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -7,6 +7,7 @@
     <p class="stat">Balance: <strong>{{ '%.2f'|format(balance) }}</strong></p>
     <p class="stat">Role: <strong>{{ current_user.role.value|capitalize }}</strong></p>
     <p class="stat">User ID: <strong>{{ current_user.id }}</strong></p>
+    <p class="stat">Handle: <strong>{{ current_user.email.split('@')[0] }}</strong></p>
     <div class="actions">
       <a class="button" href="{{ url_for('main.single_player') }}">Play solo game</a>
       <a class="button" href="{{ url_for('main.prisoners_dilemma') }}">Enter Prisoner's Dilemma</a>
@@ -18,6 +19,54 @@
         <a class="button" href="{{ url_for('main.admin_dashboard') }}">Admin Dashboard</a>
       {% endif %}
     </div>
+    {% if qr_data_uri %}
+      <div class="qr-wrapper">
+        <img src="{{ qr_data_uri }}" alt="QR code to send or request credits from {{ current_user.name }}" />
+        <p>Share this code so others can target <strong>{{ current_user.email.split('@')[0] }}</strong> when sending or requesting credits.</p>
+      </div>
+    {% endif %}
+  </article>
+  <article class="panel">
+    <h3>Send Credits</h3>
+    <form class="form" method="post" action="{{ url_for('main.handle_transfer') }}">
+      <input type="hidden" name="action" value="send" />
+      <label>
+        Recipient handle
+        <input type="text" name="handle" value="{{ target_handle }}" placeholder="friend" required />
+      </label>
+      <label>
+        Amount
+        <input type="number" name="amount" min="0.01" step="0.01" placeholder="10.00" required />
+      </label>
+      <label>
+        Message <span class="muted">(optional)</span>
+        <textarea name="message" placeholder="What is this transfer for?"></textarea>
+      </label>
+      <div class="actions">
+        <button type="submit" class="button primary">Send credits</button>
+      </div>
+    </form>
+  </article>
+  <article class="panel">
+    <h3>Request Credits</h3>
+    <form class="form" method="post" action="{{ url_for('main.handle_transfer') }}">
+      <input type="hidden" name="action" value="request" />
+      <label>
+        From handle
+        <input type="text" name="handle" value="{{ target_handle }}" placeholder="merchant" required />
+      </label>
+      <label>
+        Amount
+        <input type="number" name="amount" min="0.01" step="0.01" placeholder="25.00" required />
+      </label>
+      <label>
+        Message <span class="muted">(optional)</span>
+        <textarea name="message" placeholder="Add a note to your request."></textarea>
+      </label>
+      <div class="actions">
+        <button type="submit" class="button">Request credits</button>
+      </div>
+    </form>
   </article>
   <article class="panel">
     <h3>Recent Transactions</h3>
@@ -32,6 +81,59 @@
         <li>No transactions yet.</li>
       {% endfor %}
     </ul>
+  </article>
+  <article class="panel">
+    <h3>Incoming Requests</h3>
+    {% if incoming_requests %}
+      <div class="request-list">
+        {% for req in incoming_requests %}
+          <div class="request-item">
+            <header>
+              <strong>{{ req.requester.name }}</strong>
+              <span>{{ req.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
+            </header>
+            <p class="muted">requested <strong>{{ '%.2f'|format(req.amount) }}</strong> credits</p>
+            {% if req.message %}
+              <p class="muted">“{{ req.message }}”</p>
+            {% endif %}
+            <div class="request-item-actions">
+              <form method="post" action="{{ url_for('main.respond_money_request', request_id=req.id) }}">
+                <input type="hidden" name="action" value="accept" />
+                <button type="submit" class="button primary">Send now</button>
+              </form>
+              <form method="post" action="{{ url_for('main.respond_money_request', request_id=req.id) }}">
+                <input type="hidden" name="action" value="decline" />
+                <button type="submit" class="button danger">Decline</button>
+              </form>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="muted">No pending requests.</p>
+    {% endif %}
+  </article>
+  <article class="panel">
+    <h3>Your Requests</h3>
+    {% if outgoing_requests %}
+      <div class="request-list">
+        {% for req in outgoing_requests %}
+          <div class="request-item">
+            <header>
+              <strong>{{ req.target.name }}</strong>
+              <span>{{ req.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
+            </header>
+            <p class="muted">asked for <strong>{{ '%.2f'|format(req.amount) }}</strong> credits</p>
+            {% if req.message %}
+              <p class="muted">“{{ req.message }}”</p>
+            {% endif %}
+            <p class="muted">Status: {{ req.status|capitalize }}</p>
+          </div>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="muted">You haven't made any requests yet.</p>
+    {% endif %}
   </article>
   {% if active_match %}
     <article class="panel">


### PR DESCRIPTION
## Summary
- add a MoneyRequest model to persist pending credit requests between players
- allow players to send money, create requests by email handle, and respond to incoming requests from the dashboard
- surface transfer controls, request lists, and a shareable QR code on the dashboard with supporting styles

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d151da616c83328966e99795e22c96