### PR TITLE
Add casino games and CT earnings publication

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,12 +50,14 @@ def create_app(test_config=None):
     from .auth import bp as auth_bp
     from .routes import bp as main_bp
     from .securities import init_market
+    from .casino import init_casino
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
 
     register_cli_commands(app)
     init_market(app)
+    init_casino(app)
 
     @app.context_processor
     def inject_now():

--- a/app/casino.py
+++ b/app/casino.py
@@ -1,0 +1,461 @@
+"""Casino games, configuration, and earnings publication utilities."""
+from __future__ import annotations
+
+import random
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - defensive fallback
+    import tomli as tomllib  # type: ignore
+
+from flask import current_app, has_app_context
+from sqlalchemy.orm import joinedload
+
+from . import db
+from .models import AppSetting, Security, SecurityHolding, Transaction, User
+
+
+PENDING_KEY = "casino:pending_profit"
+LAST_PUBLISH_KEY = "casino:last_publish_at"
+SUMMARY_KEY = "casino:last_publish_summary"
+CASINO_SYMBOL = "CT"
+
+
+@dataclass
+class SlotMachine:
+    key: str
+    name: str
+    theme: str
+    symbols: List[str]
+    payout_rate: float = 0.95
+
+
+@dataclass
+class SlotSpinResult:
+    machine: SlotMachine
+    reels: List[str]
+    outcome: str
+    player_delta: float
+
+
+@dataclass
+class BlackjackResult:
+    player_cards: List[str]
+    dealer_cards: List[str]
+    player_total: int
+    dealer_total: int
+    outcome: str
+    player_delta: float
+
+
+class CasinoManager:
+    """Orchestrates casino games and dividend logic for Casino Technologies."""
+
+    publish_interval = timedelta(minutes=20)
+
+    def __init__(self, app, config_path: Path):
+        self.app = app
+        self.config_path = config_path
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self.slots: Dict[str, SlotMachine] = {}
+        self.blackjack_min_bet: float = 5.0
+        self.blackjack_max_bet: float = 250.0
+        self.blackjack_payout: float = 1.5
+        self._pending_profit: float = 0.0
+        self._last_publish: Optional[datetime] = None
+        self.reload_config()
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    # Configuration
+    def reload_config(self) -> None:
+        defaults = self._default_slots()
+        data = {}
+        try:
+            with self.config_path.open("rb") as handle:
+                data = tomllib.load(handle)
+        except FileNotFoundError:
+            data = {}
+
+        payouts_cfg = data.get("payouts", {})
+        default_slot_rate = float(payouts_cfg.get("default_slot", 0.95))
+        slot_overrides = data.get("slots", {})
+
+        slots: Dict[str, SlotMachine] = {}
+        for key, slot in defaults.items():
+            override = slot_overrides.get(key, {}) if isinstance(slot_overrides, dict) else {}
+            payout = float(override.get("payout", default_slot_rate))
+            name = str(override.get("name", slot.name))
+            theme = str(override.get("theme", slot.theme))
+            symbols = (
+                list(override.get("symbols", slot.symbols))
+                if isinstance(override.get("symbols"), list)
+                else slot.symbols
+            )
+            slots[key] = SlotMachine(
+                key=key,
+                name=name,
+                theme=theme,
+                symbols=symbols,
+                payout_rate=max(0.0, min(0.999, payout)),
+            )
+        self.slots = slots
+
+        blackjack_cfg = data.get("blackjack", {}) if isinstance(data.get("blackjack"), dict) else {}
+        try:
+            self.blackjack_min_bet = max(0.01, float(blackjack_cfg.get("min_bet", 5.0)))
+        except (TypeError, ValueError):
+            self.blackjack_min_bet = 5.0
+        try:
+            self.blackjack_max_bet = max(
+                self.blackjack_min_bet,
+                float(blackjack_cfg.get("max_bet", 250.0)),
+            )
+        except (TypeError, ValueError):
+            self.blackjack_max_bet = max(self.blackjack_min_bet, 250.0)
+        try:
+            self.blackjack_payout = max(1.0, float(blackjack_cfg.get("blackjack_payout", 1.5)))
+        except (TypeError, ValueError):
+            self.blackjack_payout = 1.5
+
+    def _default_slots(self) -> Dict[str, SlotMachine]:
+        return {
+            "nova": SlotMachine(
+                key="nova",
+                name="Nebula Nights",
+                theme="Cosmic auroras and shimmering stardust",
+                symbols=["🌠", "🪐", "✨", "☄️", "💫", "🌌"],
+            ),
+            "neon": SlotMachine(
+                key="neon",
+                name="Neon Mirage",
+                theme="Cyberpunk skylines flickering in synthwave hues",
+                symbols=["🔮", "💎", "🎰", "🛸", "💡", "🪙"],
+            ),
+            "abyss": SlotMachine(
+                key="abyss",
+                name="Abyssal Fortune",
+                theme="Deep-sea treasures guarded by luminous creatures",
+                symbols=["🐚", "🪸", "🐙", "🦑", "🔱", "🐠"],
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # State helpers
+    def _load_state(self) -> None:
+        with self.app.app_context():
+            self._pending_profit = self._get_setting_float(PENDING_KEY, 0.0)
+            self._last_publish = self._get_setting_datetime(LAST_PUBLISH_KEY)
+
+    def _get_setting(self, key: str) -> Optional[AppSetting]:
+        try:
+            return AppSetting.query.filter_by(key=key).first()
+        except Exception:
+            db.create_all()
+            return AppSetting.query.filter_by(key=key).first()
+
+    def _set_setting(self, key: str, value: str, commit: bool = False) -> None:
+        setting = self._get_setting(key)
+        if setting is None:
+            setting = AppSetting(key=key, value=value, updated_at=datetime.utcnow())
+            db.session.add(setting)
+        else:
+            setting.value = value
+            setting.updated_at = datetime.utcnow()
+        if commit:
+            db.session.commit()
+
+    def _get_setting_float(self, key: str, default: float = 0.0) -> float:
+        setting = self._get_setting(key)
+        if not setting:
+            return default
+        try:
+            return float(setting.value)
+        except (TypeError, ValueError):
+            return default
+
+    def _get_setting_datetime(self, key: str) -> Optional[datetime]:
+        setting = self._get_setting(key)
+        if not setting or not setting.value:
+            return None
+        try:
+            return datetime.fromisoformat(setting.value)
+        except ValueError:
+            return None
+
+    def _set_pending_profit(self, value: float, commit: bool = False) -> None:
+        self._pending_profit = value
+        self._set_setting(PENDING_KEY, f"{value:.6f}", commit=commit)
+
+    def _set_last_publish(self, when: datetime, summary: str, commit: bool = False) -> None:
+        self._last_publish = when
+        self._set_setting(LAST_PUBLISH_KEY, when.isoformat(), commit=False)
+        self._set_setting(SUMMARY_KEY, summary, commit=commit)
+
+    # ------------------------------------------------------------------
+    # Accessors
+    def get_slots(self) -> List[SlotMachine]:
+        return list(self.slots.values())
+
+    def get_slot(self, key: str) -> SlotMachine:
+        slot = self.slots.get(key)
+        if not slot:
+            raise ValueError("Slot machine not found.")
+        return slot
+
+    def get_status(self) -> Dict[str, Optional[object]]:
+        summary_setting = self._get_setting(SUMMARY_KEY)
+        next_publish = None
+        if self._last_publish:
+            next_publish = self._last_publish + self.publish_interval
+        return {
+            "pending_profit": self._pending_profit,
+            "last_publish_at": self._last_publish,
+            "next_publish_at": next_publish,
+            "last_summary": summary_setting.value if summary_setting else None,
+        }
+
+    # ------------------------------------------------------------------
+    # Games
+    def play_slot(self, key: str, wager: float) -> SlotSpinResult:
+        if wager <= 0:
+            raise ValueError("Wager must be positive.")
+        slot = self.get_slot(key)
+        win_probability = slot.payout_rate / 2.0
+        win_probability = max(0.0, min(1.0, win_probability))
+        win = random.random() < win_probability
+        if win:
+            symbol = random.choice(slot.symbols)
+            reels = [symbol, symbol, symbol]
+            player_delta = round(wager, 2)
+            outcome = "win"
+        else:
+            reels = [random.choice(slot.symbols) for _ in range(3)]
+            # Ensure we don't accidentally display a full match on a loss
+            if len(set(reels)) == 1:
+                reels[1] = random.choice([s for s in slot.symbols if s != reels[0]])
+            player_delta = round(-wager, 2)
+            outcome = "lose"
+        self._set_pending_profit(self._pending_profit - player_delta, commit=False)
+        return SlotSpinResult(machine=slot, reels=reels, outcome=outcome, player_delta=player_delta)
+
+    def play_blackjack(self, wager: float) -> BlackjackResult:
+        if wager <= 0:
+            raise ValueError("Wager must be positive.")
+        if wager < self.blackjack_min_bet or wager > self.blackjack_max_bet:
+            raise ValueError(
+                f"Blackjack wager must be between {self.blackjack_min_bet:.2f} and {self.blackjack_max_bet:.2f}."
+            )
+
+        deck = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
+
+        def draw_card() -> str:
+            return random.choice(deck)
+
+        def hand_value(cards: List[str]) -> int:
+            total = 0
+            aces = 0
+            for card in cards:
+                if card == "A":
+                    aces += 1
+                    total += 11
+                elif card in {"J", "Q", "K"}:
+                    total += 10
+                else:
+                    total += int(card)
+            while total > 21 and aces:
+                total -= 10
+                aces -= 1
+            return total
+
+        player_cards = [draw_card(), draw_card()]
+        dealer_cards = [draw_card(), draw_card()]
+        player_total = hand_value(player_cards)
+        dealer_total = hand_value(dealer_cards)
+        natural_player = player_total == 21
+        natural_dealer = dealer_total == 21
+
+        if not natural_player:
+            while player_total < 17:
+                player_cards.append(draw_card())
+                player_total = hand_value(player_cards)
+                if player_total > 21:
+                    break
+
+        if player_total <= 21:
+            while dealer_total < 17:
+                dealer_cards.append(draw_card())
+                dealer_total = hand_value(dealer_cards)
+
+        if player_total > 21:
+            outcome = "bust"
+            player_delta = round(-wager, 2)
+        elif natural_player and not natural_dealer:
+            payout = wager * self.blackjack_payout
+            player_delta = round(payout - wager, 2)
+            outcome = "blackjack"
+        elif dealer_total > 21 or player_total > dealer_total:
+            player_delta = round(wager, 2)
+            outcome = "win"
+        elif player_total == dealer_total:
+            player_delta = 0.0
+            outcome = "push"
+        else:
+            player_delta = round(-wager, 2)
+            outcome = "lose"
+
+        self._set_pending_profit(self._pending_profit - player_delta, commit=False)
+        return BlackjackResult(
+            player_cards=player_cards,
+            dealer_cards=dealer_cards,
+            player_total=player_total,
+            dealer_total=dealer_total,
+            outcome=outcome,
+            player_delta=player_delta,
+        )
+
+    # ------------------------------------------------------------------
+    # Earnings publication
+    def publish_earnings_if_due(self, *, force: bool = False) -> Optional[str]:
+        now = datetime.utcnow()
+        with self._lock:
+            if force or self._should_publish(now):
+                return self._publish_earnings(now)
+        return None
+
+    def _should_publish(self, now: datetime) -> bool:
+        if self._last_publish is None:
+            return True
+        return now - self._last_publish >= self.publish_interval
+
+    def _publish_earnings(self, now: datetime) -> str:
+        profit = self._pending_profit
+        summary = "No casino activity this period."
+        try:
+            if abs(profit) < 1e-6:
+                summary = "Casino held steady; no dividends or buybacks were required."
+            elif profit > 0:
+                summary = self._distribute_dividends(profit)
+            else:
+                summary = self._cover_losses(-profit)
+            self._set_pending_profit(0.0, commit=False)
+            self._set_last_publish(now, summary, commit=False)
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            raise
+        finally:
+            db.session.remove()
+        return summary
+
+    def _distribute_dividends(self, profit: float) -> str:
+        dividend_pool = profit * 0.5
+        holdings = (
+            SecurityHolding.query.filter(
+                SecurityHolding.security_symbol == CASINO_SYMBOL,
+                SecurityHolding.quantity > 0,
+            )
+            .options(joinedload(SecurityHolding.user))
+            .all()
+        )
+        total_shares = sum(float(h.quantity or 0.0) for h in holdings)
+        if total_shares <= 0:
+            return "Casino earned profit but no outstanding shares existed; retained earnings."
+        per_share = dividend_pool / total_shares
+        for holding in holdings:
+            qty = float(holding.quantity or 0.0)
+            if qty <= 0:
+                continue
+            amount = qty * per_share
+            if abs(amount) < 1e-6:
+                continue
+            user = holding.user or User.query.get(holding.user_id)
+            if not user:
+                continue
+            user.balance += amount
+            txn = Transaction(
+                user_id=user.id,
+                amount=amount,
+                description="Casino Technologies dividend",
+                type="dividend",
+            )
+            db.session.add(txn)
+        db.session.flush()
+        return (
+            f"Casino distributed {dividend_pool:.2f} credits in dividends at {per_share:.4f} per share."
+        )
+
+    def _cover_losses(self, loss: float) -> str:
+        security = Security.query.get(CASINO_SYMBOL)
+        if not security:
+            return "Casino recorded a loss but CT security is unavailable."
+        price = max(0.01, security.last_price)
+        quantity = loss / price
+        simulator = getattr(current_app, "market_simulator", None)
+        if simulator is not None:
+            simulator.apply_order_impact(CASINO_SYMBOL, -quantity)
+        db.session.flush()
+        return (
+            f"Casino covered losses of {loss:.2f} credits by issuing approximately {quantity:.2f} CT shares."
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name="casino-manager", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1)
+
+    def _run(self) -> None:  # pragma: no cover - background thread
+        with self.app.app_context():
+            while not self._stop.is_set():
+                start = time.monotonic()
+                try:
+                    self.publish_earnings_if_due()
+                except Exception:
+                    db.session.rollback()
+                elapsed = time.monotonic() - start
+                delay = max(30.0, 60.0 - elapsed)
+                time.sleep(delay)
+
+
+# ----------------------------------------------------------------------
+# Application helpers
+
+def init_casino(app) -> CasinoManager:
+    config_path = Path(app.root_path) / "config" / "casino.toml"
+    manager = CasinoManager(app, config_path)
+
+    @app.before_request
+    def _ensure_casino_running() -> None:  # pragma: no cover - background thread
+        if not getattr(app, "_casino_thread_started", False):
+            manager.start()
+            setattr(app, "_casino_thread_started", True)
+
+    import atexit
+
+    atexit.register(manager.stop)
+    app.casino_manager = manager
+    return manager
+
+
+def get_casino_manager() -> CasinoManager:
+    if has_app_context():
+        return current_app.casino_manager
+    raise RuntimeError("No active Flask application context.")
+

--- a/app/config/casino.toml
+++ b/app/config/casino.toml
@@ -1,0 +1,16 @@
+[payouts]
+default_slot = 0.95
+
+[slots.nova]
+payout = 0.96
+
+[slots.neon]
+payout = 0.94
+
+[slots.abyss]
+payout = 0.95
+
+[blackjack]
+min_bet = 5.0
+max_bet = 250.0
+blackjack_payout = 1.5

--- a/app/routes.py
+++ b/app/routes.py
@@ -466,11 +466,9 @@ def single_player():
 def casino():
     manager = get_casino_manager()
     AppSetting.set("current_game_context", "casino")
-    status = manager.get_status()
     return render_template(
         "casino.html",
         slots=manager.get_slots(),
-        status=status,
         manager=manager,
     )
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -138,33 +138,6 @@ button.danger:hover {
   grid-column: 1 / -1;
 }
 
-.casino-status {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
-}
-
-.casino-status .label {
-  display: block;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  color: var(--muted);
-  letter-spacing: 0.08em;
-}
-
-.casino-status .value {
-  font-size: 1.1rem;
-  font-weight: 700;
-}
-
-.casino-status .wide {
-  grid-column: 1 / -1;
-  padding: 0.75rem;
-  background: rgba(26, 255, 213, 0.05);
-  border-radius: 6px;
-}
-
 .casino-grid {
   display: grid;
   gap: 1.5rem;
@@ -191,12 +164,6 @@ button.danger:hover {
   font-size: 0.85rem;
   color: var(--muted);
   min-height: 2.4rem;
-}
-
-.casino-machine .payout {
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--accent);
 }
 
 .casino-form {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -138,6 +138,96 @@ button.danger:hover {
   grid-column: 1 / -1;
 }
 
+.casino-status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.casino-status .label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+}
+
+.casino-status .value {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.casino-status .wide {
+  grid-column: 1 / -1;
+  padding: 0.75rem;
+  background: rgba(26, 255, 213, 0.05);
+  border-radius: 6px;
+}
+
+.casino-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-top: 1rem;
+}
+
+.casino-machine {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(26, 255, 213, 0.2);
+  border-radius: 10px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 12px rgba(26, 255, 213, 0.12);
+}
+
+.casino-machine h3 {
+  margin: 0;
+}
+
+.casino-machine .theme {
+  font-size: 0.85rem;
+  color: var(--muted);
+  min-height: 2.4rem;
+}
+
+.casino-machine .payout {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.casino-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.casino-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+
+.casino-form input[type="number"] {
+  padding: 0.5rem 0.6rem;
+  background: #0f161d;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text);
+  border-radius: 4px;
+}
+
+.casino-form.blackjack {
+  max-width: 420px;
+}
+
+.casino-form button {
+  align-self: flex-start;
+}
+
 .grid {
   display: grid;
   gap: 1.5rem;

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -40,6 +40,21 @@
   </article>
 
   <article class="panel">
+    <h2>Casino Earnings</h2>
+    {% set status = casino_status or {} %}
+    <ul class="list">
+      <li>Pending profit: {{ '%.2f'|format(status.get('pending_profit', 0.0) or 0.0) }} credits</li>
+      <li>Last publication: {{ status.get('last_publish_at').strftime('%Y-%m-%d %H:%M:%S') if status.get('last_publish_at') else 'Never' }}</li>
+      <li>Next scheduled: {{ status.get('next_publish_at').strftime('%Y-%m-%d %H:%M:%S') if status.get('next_publish_at') else 'Pending' }}</li>
+      <li>Last summary: {{ status.get('last_summary') or 'No publication yet.' }}</li>
+    </ul>
+    <form method="post" action="{{ url_for('main.admin_casino_publish') }}" class="form">
+      <button class="button" type="submit">Publish Earnings Now</button>
+    </form>
+    <p class="note">Immediately run the casino dividend/buyback cycle regardless of schedule.</p>
+  </article>
+
+  <article class="panel">
     <h2>Pricing & Reward Sensitivities</h2>
     <form method="post" action="{{ url_for('main.update_pricing_settings') }}" class="form">
       <label>Increase on purchase (%)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,6 +20,7 @@
           <a href="{{ url_for('main.single_player') }}">Solo Game</a>
           <a href="{{ url_for('main.prisoners_dilemma') }}">Prisoner's Dilemma</a>
           <a href="{{ url_for('main.securities_hub') }}">Securities</a>
+          <a href="{{ url_for('main.casino') }}">Casino</a>
           {% if current_user.is_merchant %}
             <a href="{{ url_for('main.merchant_portal') }}">Merchant</a>
           {% endif %}

--- a/app/templates/casino.html
+++ b/app/templates/casino.html
@@ -2,31 +2,11 @@
 {% block title %}Casino · Invisible Hand Arcade{% endblock %}
 {% block content %}
 <section class="panel wide">
-  <h1>Casino Technologies Trading Floor</h1>
+  <h1>Casino Arcade</h1>
   <p>
-    Spin up earnings for <strong>CT</strong> with neon slots and instant blackjack hands.
-    Dividends are published every twenty minutes based on the house ledger.
+    Welcome to the high-gloss floor of the Invisible Hand arcade. Grab a seat, pick your favorite
+    machine, and chase a hot streak — the house will keep tabs while you focus on the fun.
   </p>
-  <div class="casino-status">
-    <div>
-      <span class="label">Pending profit</span>
-      <span class="value">{{ status.pending_profit|round(2) }}</span>
-    </div>
-    <div>
-      <span class="label">Last publish</span>
-      <span class="value">{{ status.last_publish_at or "–" }}</span>
-    </div>
-    <div>
-      <span class="label">Next publish</span>
-      <span class="value">{{ status.next_publish_at or "–" }}</span>
-    </div>
-    {% if status.last_summary %}
-    <div class="wide">
-      <span class="label">Last action</span>
-      <span class="value">{{ status.last_summary }}</span>
-    </div>
-    {% endif %}
-  </div>
 </section>
 
 <section class="panel wide">
@@ -36,7 +16,6 @@
       <div class="casino-machine">
         <h3>{{ slot.name }}</h3>
         <p class="theme">{{ slot.theme }}</p>
-        <p class="payout">Configured payout rate: {{ '%.2f'|format(slot.payout_rate) }}</p>
         <form method="post" action="{{ url_for('main.play_slot') }}" class="casino-form">
           <input type="hidden" name="slot_id" value="{{ slot.key }}">
           <label>
@@ -52,10 +31,7 @@
 
 <section class="panel wide">
   <h2>Quick Blackjack</h2>
-  <p>
-    Hands resolve automatically with classic rules: players stand on 17, dealers hit on soft 16, and
-    naturals pay {{ '%.2f'|format(manager.blackjack_payout) }}×.
-  </p>
+  <p>Hands resolve automatically with classic rules — stand on 17, watch the dealer draw, and see who takes the pot.</p>
   <form method="post" action="{{ url_for('main.play_blackjack') }}" class="casino-form blackjack">
     <label>
       Wager ({{ manager.blackjack_min_bet|round(2) }} – {{ manager.blackjack_max_bet|round(2) }})

--- a/app/templates/casino.html
+++ b/app/templates/casino.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block title %}Casino · Invisible Hand Arcade{% endblock %}
+{% block content %}
+<section class="panel wide">
+  <h1>Casino Technologies Trading Floor</h1>
+  <p>
+    Spin up earnings for <strong>CT</strong> with neon slots and instant blackjack hands.
+    Dividends are published every twenty minutes based on the house ledger.
+  </p>
+  <div class="casino-status">
+    <div>
+      <span class="label">Pending profit</span>
+      <span class="value">{{ status.pending_profit|round(2) }}</span>
+    </div>
+    <div>
+      <span class="label">Last publish</span>
+      <span class="value">{{ status.last_publish_at or "–" }}</span>
+    </div>
+    <div>
+      <span class="label">Next publish</span>
+      <span class="value">{{ status.next_publish_at or "–" }}</span>
+    </div>
+    {% if status.last_summary %}
+    <div class="wide">
+      <span class="label">Last action</span>
+      <span class="value">{{ status.last_summary }}</span>
+    </div>
+    {% endif %}
+  </div>
+</section>
+
+<section class="panel wide">
+  <h2>Slots Lobby</h2>
+  <div class="casino-grid">
+    {% for slot in slots %}
+      <div class="casino-machine">
+        <h3>{{ slot.name }}</h3>
+        <p class="theme">{{ slot.theme }}</p>
+        <p class="payout">Configured payout rate: {{ '%.2f'|format(slot.payout_rate) }}</p>
+        <form method="post" action="{{ url_for('main.play_slot') }}" class="casino-form">
+          <input type="hidden" name="slot_id" value="{{ slot.key }}">
+          <label>
+            Wager
+            <input type="number" name="wager" min="0.01" step="0.01" value="5.00" required>
+          </label>
+          <button type="submit" class="primary">Spin</button>
+        </form>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="panel wide">
+  <h2>Quick Blackjack</h2>
+  <p>
+    Hands resolve automatically with classic rules: players stand on 17, dealers hit on soft 16, and
+    naturals pay {{ '%.2f'|format(manager.blackjack_payout) }}×.
+  </p>
+  <form method="post" action="{{ url_for('main.play_blackjack') }}" class="casino-form blackjack">
+    <label>
+      Wager ({{ manager.blackjack_min_bet|round(2) }} – {{ manager.blackjack_max_bet|round(2) }})
+      <input type="number" name="wager" step="0.01" min="{{ manager.blackjack_min_bet }}" max="{{ manager.blackjack_max_bet }}" value="{{ manager.blackjack_min_bet }}" required>
+    </label>
+    <button type="submit" class="primary">Deal</button>
+  </form>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a casino manager that runs slots, blackjack, and 20 minute CT dividend/buyback cycles
- expose a new Casino tab with themed slot machines and quick blackjack using configurable payout rates
- wire the casino manager into app startup with supporting templates, styles, and configuration

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d16440ae548332bb904ecc18949282