### PR TITLE
Add shareholder voting system

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -112,6 +112,18 @@ button.primary {
   color: #001217;
 }
 
+.button.secondary,
+button.secondary {
+  border-color: rgba(26, 255, 213, 0.5);
+  color: var(--accent);
+}
+
+.button.secondary:hover,
+button.secondary:hover {
+  background: rgba(26, 255, 213, 0.15);
+  color: var(--text);
+}
+
 .button:hover,
 button:hover {
   background: var(--accent-strong);
@@ -557,6 +569,23 @@ button.danger:hover {
   border-bottom: none;
 }
 
+.vote-admin-columns {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.vote-list li {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.vote-list li a.button {
+  margin-top: 0.35rem;
+}
+
 .quotes {
   width: 100%;
   border-collapse: collapse;
@@ -609,6 +638,156 @@ button.danger:hover {
 .muted {
   color: var(--muted);
   font-size: 0.85rem;
+}
+
+.inbox-grid .panel {
+  min-height: 0;
+}
+
+.alert-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.alert-item {
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.alert-item.unread {
+  border-color: var(--accent);
+  box-shadow: 0 0 8px rgba(26, 255, 213, 0.2);
+}
+
+.alert-item h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.alert-item.alert-vote_result {
+  border-color: rgba(26, 255, 213, 0.4);
+}
+
+.alert-item.alert-vote_invite {
+  border-color: rgba(26, 255, 213, 0.25);
+}
+
+.alert-item header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.alert-item p {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.vote-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.vote-bar {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(160px, 2fr) minmax(120px, auto);
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.vote-bar-label {
+  font-weight: 600;
+}
+
+.vote-bar-track {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+  height: 0.65rem;
+}
+
+.vote-bar-fill {
+  background: var(--accent);
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.vote-bar.muted .vote-bar-fill {
+  background: rgba(120, 144, 156, 0.6);
+}
+
+.vote-bar-value {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.vote-detail h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.vote-message {
+  margin: 1rem 0;
+  line-height: 1.5;
+}
+
+.vote-form {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.vote-form .radio {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.vote-form button {
+  align-self: flex-start;
+}
+
+.inbox-requests {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.inbox-requests li {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.inbox-requests header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.inbox-requests p {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
 }
 
 .change.positive,
@@ -925,6 +1104,34 @@ button.danger:hover {
   margin-top: 0.4rem;
   min-height: 3.5rem;
   resize: vertical;
+}
+
+.form .fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.form .fieldset legend {
+  padding: 0 0.35rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.form .radio {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  text-transform: none;
+  margin-bottom: 0.5rem;
+}
+
+.form .radio input[type="radio"] {
+  width: auto;
+  margin: 0;
 }
 
 .form .actions {

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -104,6 +104,105 @@
   </article>
 
   <article class="panel">
+    <h2>Send Player Alert</h2>
+    <form method="post" action="{{ url_for('main.create_alert') }}" class="form">
+      <label>Message
+        <textarea name="message" required placeholder="What's happening?" rows="3"></textarea>
+      </label>
+      <fieldset class="fieldset">
+        <legend>Audience</legend>
+        <label class="radio">
+          <input type="radio" name="audience" value="all" checked>
+          All players
+        </label>
+        <label class="radio">
+          <input type="radio" name="audience" value="handle">
+          Specific handle
+        </label>
+        <input type="text" name="target_handle" placeholder="player-handle" />
+      </fieldset>
+      <button class="button" type="submit">Send alert</button>
+    </form>
+    <p class="note">Alerts show up in the new player inbox. Handles use the part of their email before the @ symbol.</p>
+  </article>
+
+  <article class="panel">
+    <h2>Shareholder Votes</h2>
+    <form method="post" action="{{ url_for('main.create_shareholder_vote') }}" class="form">
+      <label>Security
+        <select name="security_symbol" required>
+          {% for security in securities %}
+            <option value="{{ security.symbol }}">{{ security.symbol }} — {{ security.name }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Title
+        <input type="text" name="vote_title" required placeholder="Annual meeting proposal">
+      </label>
+      <label>Message
+        <textarea name="vote_message" rows="3" required placeholder="Describe the proposal and any relevant context."></textarea>
+      </label>
+      <label>Options (one per line)
+        <textarea name="vote_options" rows="3" required placeholder="Approve&#10;Reject"></textarea>
+      </label>
+      <label>Voting deadline
+        <input type="datetime-local" name="vote_deadline" required>
+      </label>
+      <button class="button" type="submit">Start vote</button>
+    </form>
+    <p class="note">Players holding the selected security receive an alert with a link to the vote. Voting weight is based on shares held at the deadline.</p>
+
+    <div class="vote-admin-columns">
+      <div>
+        <h3>Open votes</h3>
+        <ul class="list vote-list">
+          {% for vote in open_votes %}
+            <li>
+              <strong>{{ vote.title }}</strong>
+              <span class="muted">{{ vote.security_symbol }} · closes {{ vote.deadline.strftime('%Y-%m-%d %H:%M') }}</span>
+              <a class="button secondary" href="{{ url_for('main.view_shareholder_vote', vote_id=vote.id) }}">View vote</a>
+            </li>
+          {% else %}
+            <li>No open votes.</li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div>
+        <h3>Recent votes</h3>
+        <ul class="list vote-list">
+          {% for vote in recent_votes %}
+            <li>
+              <strong>{{ vote.title }}</strong>
+              {% if vote.finalized_at %}
+                <span class="muted">Closed {{ vote.finalized_at.strftime('%Y-%m-%d %H:%M') }}</span>
+              {% else %}
+                <span class="muted">Open · closes {{ vote.deadline.strftime('%Y-%m-%d %H:%M') }}</span>
+              {% endif %}
+              <a class="button secondary" href="{{ url_for('main.view_shareholder_vote', vote_id=vote.id) }}">Details</a>
+            </li>
+          {% else %}
+            <li>No votes yet.</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </article>
+
+  <article class="panel">
+    <h2>Recent Alerts</h2>
+    <ul class="list">
+      {% for alert in alerts %}
+        <li>
+          <span>{{ alert.created_at.strftime('%H:%M:%S') }}</span>
+          <span>{{ alert.creator.name if alert.creator else 'Admin' }} — {{ alert.title or alert.message }}</span>
+        </li>
+      {% else %}
+        <li>No alerts sent yet.</li>
+      {% endfor %}
+    </ul>
+  </article>
+
+  <article class="panel">
     <h2>Per-Product Sensitivities</h2>
     <form method="post" action="{{ url_for('main.merchant_portal') }}" class="form">
       <input type="hidden" name="action" value="update_product_increase_pct">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,6 +17,7 @@
         <a href="{{ url_for('main.index') }}">Home</a>
         {% if current_user.is_authenticated %}
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
+          <a href="{{ url_for('main.inbox') }}">Inbox</a>
           <a href="{{ url_for('main.single_player') }}">Solo Game</a>
           <a href="{{ url_for('main.prisoners_dilemma') }}">Prisoner's Dilemma</a>
           <a href="{{ url_for('main.securities_hub') }}">Securities</a>

--- a/app/templates/inbox.html
+++ b/app/templates/inbox.html
@@ -1,0 +1,111 @@
+{% extends 'base.html' %}
+{% block title %}Inbox{% endblock %}
+{% block content %}
+<section class="grid inbox-grid">
+  <article class="panel wide">
+    <h2>Alerts from Admin</h2>
+    {% if alert_receipts %}
+      <ul class="alert-list">
+        {% for receipt in alert_receipts %}
+          {% set alert = receipt.alert %}
+          {% set payload = alert.payload or {} %}
+          <li class="alert-item {{ 'unread' if receipt.read_at is none else '' }} alert-{{ alert.category }}">
+            <header>
+              <div>
+                <strong>{{ alert.creator.name if alert.creator else 'Admin' }}</strong>
+                <span class="muted">{{ alert.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
+              </div>
+              {% if alert.title %}
+                <h3>{{ alert.title }}</h3>
+              {% endif %}
+            </header>
+            <p>{{ alert.message }}</p>
+            {% if alert.category == 'vote_invite' and payload.get('vote_id') %}
+              <p><a class="button secondary" href="{{ url_for('main.view_shareholder_vote', vote_id=payload.get('vote_id')) }}">Review and vote</a></p>
+              <p class="muted">Deadline: {{ payload.get('deadline')|replace('T', ' ') if payload.get('deadline') else 'See details' }}</p>
+            {% elif alert.category == 'vote_result' %}
+              {% set results = payload.get('results') or {} %}
+              {% set options = results.get('options') or [] %}
+              {% set total = results.get('total_shares') or 0 %}
+              <div class="vote-chart">
+                {% for option in options %}
+                  {% set shares = option.get('shares', 0) %}
+                  {% set pct = (shares / total * 100) if total else 0 %}
+                  <div class="vote-bar">
+                    <div class="vote-bar-label">{{ option.get('label') }}</div>
+                    <div class="vote-bar-track">
+                      <div class="vote-bar-fill" style="width: {{ '%.1f'|format(pct) }}%"></div>
+                    </div>
+                    <div class="vote-bar-value">{{ '%.2f'|format(shares) }} shares</div>
+                  </div>
+                {% endfor %}
+                {% set unvoted = results.get('unvoted_shares') or 0 %}
+                <div class="vote-bar muted">
+                  <div class="vote-bar-label">Not voted</div>
+                  {% set unvoted_pct = (unvoted / total * 100) if total else 0 %}
+                  <div class="vote-bar-track">
+                    <div class="vote-bar-fill" style="width: {{ '%.1f'|format(unvoted_pct) }}%"></div>
+                  </div>
+                  <div class="vote-bar-value">{{ '%.2f'|format(unvoted) }} shares</div>
+                </div>
+                <p class="muted">Total eligible shares: {{ '%.2f'|format(total) }}</p>
+              </div>
+            {% endif %}
+            {% if receipt.read_at %}
+              <span class="muted">Read {{ receipt.read_at.strftime('%Y-%m-%d %H:%M') }}</span>
+            {% else %}
+              <span class="muted">New</span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="muted">No alerts yet.</p>
+    {% endif %}
+  </article>
+  <article class="panel">
+    <h3>Requests You Received</h3>
+    {% if incoming_requests %}
+      <ul class="inbox-requests">
+        {% for req in incoming_requests %}
+          <li>
+            <header>
+              <strong>{{ req.requester.name }}</strong>
+              <span>{{ req.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
+            </header>
+            <p>Requested <strong>{{ '%.2f'|format(req.amount) }}</strong> credits.</p>
+            {% if req.message %}
+              <p class="muted">“{{ req.message }}”</p>
+            {% endif %}
+            <p class="muted">Status: {{ req.status|capitalize }}</p>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="muted">No one has requested credits from you yet.</p>
+    {% endif %}
+  </article>
+  <article class="panel">
+    <h3>Requests You Sent</h3>
+    {% if outgoing_requests %}
+      <ul class="inbox-requests">
+        {% for req in outgoing_requests %}
+          <li>
+            <header>
+              <strong>{{ req.target.name }}</strong>
+              <span>{{ req.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
+            </header>
+            <p>Asked for <strong>{{ '%.2f'|format(req.amount) }}</strong> credits.</p>
+            {% if req.message %}
+              <p class="muted">“{{ req.message }}”</p>
+            {% endif %}
+            <p class="muted">Status: {{ req.status|capitalize }}</p>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="muted">You haven't sent any requests yet.</p>
+    {% endif %}
+  </article>
+</section>
+{% endblock %}

--- a/app/templates/shareholder_vote.html
+++ b/app/templates/shareholder_vote.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+{% block title %}Shareholder Vote · {{ vote.title }}{% endblock %}
+{% block content %}
+<section class="grid">
+  <article class="panel wide vote-detail">
+    <h1>{{ vote.title }}</h1>
+    <p class="muted">Security {{ vote.security_symbol }} · Created {{ vote.created_at.strftime('%Y-%m-%d %H:%M') }}</p>
+    <div class="vote-message">{{ vote.message | replace('\n', '<br>') | safe }}</div>
+    {% if voting_open %}
+      <p class="note">Voting closes at {{ vote.deadline.strftime('%Y-%m-%d %H:%M') }} UTC.</p>
+    {% else %}
+      <p class="note">Voting closed {{ vote.deadline.strftime('%Y-%m-%d %H:%M') }} UTC.</p>
+    {% endif %}
+    <p class="muted">You currently hold {{ '%.2f'|format(current_shares) }} shares. Final weight is based on holdings at the deadline.</p>
+
+    {% set options = chart_data.get('options') or [] %}
+    {% set total = chart_data.get('total_shares') or 0 %}
+    {% set unvoted = chart_data.get('unvoted_shares') or 0 %}
+    <div class="vote-chart">
+      {% for option in options %}
+        {% set shares = option.get('shares', 0) %}
+        {% set pct = (shares / total * 100) if total else 0 %}
+        <div class="vote-bar">
+          <div class="vote-bar-label">{{ option.get('label') }}</div>
+          <div class="vote-bar-track">
+            <div class="vote-bar-fill" style="width: {{ '%.1f'|format(pct) }}%"></div>
+          </div>
+          <div class="vote-bar-value">{{ '%.2f'|format(shares) }} shares</div>
+        </div>
+      {% endfor %}
+      <div class="vote-bar muted">
+        <div class="vote-bar-label">Not voted</div>
+        {% set unvoted_pct = (unvoted / total * 100) if total else 0 %}
+        <div class="vote-bar-track">
+          <div class="vote-bar-fill" style="width: {{ '%.1f'|format(unvoted_pct) }}%"></div>
+        </div>
+        <div class="vote-bar-value">{{ '%.2f'|format(unvoted) }} shares</div>
+      </div>
+      <p class="muted">Total eligible shares: {{ '%.2f'|format(total) }}</p>
+    </div>
+
+    {% if voting_open %}
+      <form method="post" action="{{ url_for('main.cast_shareholder_vote', vote_id=vote.id) }}" class="form vote-form">
+        <fieldset class="fieldset">
+          <legend>Cast your vote</legend>
+          {% for option in vote.options %}
+            <label class="radio">
+              <input type="radio" name="option_id" value="{{ option.id }}" {% if ballot and ballot.option_id == option.id %}checked{% endif %} required>
+              {{ option.label }}
+            </label>
+          {% endfor %}
+        </fieldset>
+        <button class="button primary" type="submit">Submit vote</button>
+      </form>
+    {% else %}
+      <p class="note">Voting is closed. Results are final.</p>
+    {% endif %}
+  </article>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce shareholder vote models and alert metadata to support targeted voting announcements and results
- allow admins to launch security-specific votes with configurable options and deadlines from the dashboard
- deliver player-facing vote pages, inbox integrations, and retroactive notifications so shareholders can cast ballots and review tallies

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a2f325d8833285cd5302f4e6d17e