### PR TITLE
Add unit tests for casino configuration and role privileges

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,123 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Stub flask module
+if "flask" not in sys.modules:
+    flask_stub = types.ModuleType("flask")
+    flask_stub.current_app = types.SimpleNamespace()
+
+    def has_app_context():
+        return False
+
+    flask_stub.has_app_context = has_app_context
+    flask_stub.before_request = lambda func: func
+    sys.modules["flask"] = flask_stub
+
+# Stub flask_login module
+if "flask_login" not in sys.modules:
+    flask_login_stub = types.ModuleType("flask_login")
+    flask_login_stub.UserMixin = type("UserMixin", (), {})
+    flask_login_stub.LoginManager = type("LoginManager", (), {"user_loader": lambda self, func: func})
+    flask_login_stub.login_required = lambda func: func
+    flask_login_stub.current_user = object()
+    flask_login_stub.user_loader = lambda func: func
+    sys.modules["flask_login"] = flask_login_stub
+
+# Stub sqlalchemy modules
+if "sqlalchemy" not in sys.modules:
+    sqlalchemy_stub = types.ModuleType("sqlalchemy")
+
+    def check_constraint(*args, **kwargs):
+        return None
+
+    class DummyEnum:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    sqlalchemy_stub.CheckConstraint = check_constraint
+    sqlalchemy_stub.Enum = DummyEnum
+    sys.modules["sqlalchemy"] = sqlalchemy_stub
+
+if "sqlalchemy.orm" not in sys.modules:
+    orm_stub = types.ModuleType("sqlalchemy.orm")
+    orm_stub.joinedload = lambda *args, **kwargs: None
+    sys.modules["sqlalchemy.orm"] = orm_stub
+
+# Stub application package with minimal db/login_manager
+if "app" not in sys.modules:
+    app_pkg = types.ModuleType("app")
+    app_pkg.__path__ = [str(ROOT / "app")]
+
+    class DummySession:
+        def add(self, *args, **kwargs):
+            pass
+
+        def commit(self, *args, **kwargs):
+            pass
+
+        def rollback(self, *args, **kwargs):
+            pass
+
+        def flush(self, *args, **kwargs):
+            pass
+
+        def remove(self, *args, **kwargs):
+            pass
+
+        def delete(self, *args, **kwargs):
+            pass
+
+    class DummySQLAlchemy:
+        session = DummySession()
+        Model = type("Model", (), {})
+        Integer = int
+        Float = float
+        String = str
+        DateTime = object
+        JSON = dict
+        Text = str
+        Boolean = bool
+
+        @staticmethod
+        def Column(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def ForeignKey(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def relationship(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def backref(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def UniqueConstraint(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def create_all(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def drop_all(*args, **kwargs):
+            pass
+
+    app_pkg.db = DummySQLAlchemy()
+
+    class DummyLoginManager:
+        def user_loader(self, func):
+            return func
+
+    app_pkg.login_manager = DummyLoginManager()
+    app_pkg.oauth = object()
+
+    sys.modules["app"] = app_pkg

--- a/tests/test_casino.py
+++ b/tests/test_casino.py
@@ -1,0 +1,125 @@
+import importlib.util
+import sys
+import threading
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+_module_path = Path(__file__).resolve().parents[1] / "app" / "casino.py"
+_spec = importlib.util.spec_from_file_location("app.casino", _module_path)
+casino = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("app.casino", casino)
+assert _spec and _spec.loader
+_spec.loader.exec_module(casino)
+CasinoManager = casino.CasinoManager
+
+
+def make_manager(config_path):
+    manager = object.__new__(CasinoManager)
+    manager.app = None
+    manager.config_path = config_path
+    manager._lock = threading.Lock()
+    manager._thread = None
+    manager._stop = threading.Event()
+    manager.slots = {}
+    manager.blackjack_min_bet = 5.0
+    manager.blackjack_max_bet = 250.0
+    manager.blackjack_payout = 1.5
+    manager._pending_profit = 0.0
+    manager._last_publish = None
+    manager.reload_config()
+    return manager
+
+
+def test_reload_config_applies_overrides(tmp_path):
+    config_path = tmp_path / "casino.toml"
+    config_path.write_text(
+        """
+[payouts]
+default_slot = 0.85
+
+[slots.nova]
+payout = 5.0
+name = "Custom Nova"
+theme = "Custom Theme"
+symbols = ["A", "B", "C", "D", "E", "F"]
+
+[[slots.nova.prizes]]
+symbol = "X"
+label = "Custom Jackpot"
+multiplier = 3.0
+image = "jackpot.png"
+
+[[slots.nova.prizes]]
+symbol = "Y"
+multiplier = 1.5
+
+[blackjack]
+min_bet = 2.5
+max_bet = 150.0
+blackjack_payout = 2.0
+"""
+    )
+
+    manager = make_manager(config_path)
+
+    nova = manager.get_slot("nova")
+    assert nova.name == "Custom Nova"
+    assert nova.theme == "Custom Theme"
+    assert nova.payout_rate == pytest.approx(0.999)
+    assert [prize.symbol for prize in nova.prizes] == ["X", "Y"]
+    assert nova.symbols == ["X", "Y"]
+
+    neon = manager.get_slot("neon")
+    assert neon.payout_rate == pytest.approx(0.85)
+
+    assert manager.blackjack_min_bet == pytest.approx(2.5)
+    assert manager.blackjack_max_bet == pytest.approx(150.0)
+    assert manager.blackjack_payout == pytest.approx(2.0)
+
+
+def test_get_slot_invalid_key_raises(tmp_path):
+    config_path = tmp_path / "casino.toml"
+    config_path.write_text("")
+
+    manager = make_manager(config_path)
+
+    with pytest.raises(ValueError):
+        manager.get_slot("missing")
+
+
+def test_evaluate_slot_grid_multiple_wins(tmp_path):
+    config_path = tmp_path / "casino.toml"
+    config_path.write_text("")
+
+    manager = make_manager(config_path)
+    slot = manager.get_slot("nova")
+    prize_lookup = {prize.symbol: prize for prize in slot.prizes}
+
+    winning_symbol = slot.prizes[0].symbol
+    reels = [[winning_symbol for _ in range(3)] for _ in range(3)]
+
+    wins = manager._evaluate_slot_grid(reels, prize_lookup, wager=10.0)
+
+    assert len(wins) == 8
+    assert all(win.prize.symbol == winning_symbol for win in wins)
+    expected_payout = pytest.approx(10.0 * slot.prizes[0].multiplier)
+    assert all(win.payout == expected_payout for win in wins)
+
+
+def test_should_publish_based_on_interval(tmp_path):
+    config_path = tmp_path / "casino.toml"
+    config_path.write_text("")
+
+    manager = make_manager(config_path)
+
+    now = datetime.utcnow()
+    manager._last_publish = None
+    assert manager._should_publish(now) is True
+
+    manager._last_publish = now - manager.publish_interval + timedelta(minutes=1)
+    assert manager._should_publish(now) is False
+
+    manager._last_publish = now - manager.publish_interval
+    assert manager._should_publish(now) is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,20 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+_module_path = Path(__file__).resolve().parents[1] / "app" / "models.py"
+_spec = importlib.util.spec_from_file_location("app.models", _module_path)
+models = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("app.models", models)
+assert _spec and _spec.loader
+_spec.loader.exec_module(models)
+Role = models.Role
+
+
+def test_role_privilege_hierarchy():
+    assert Role.ADMIN.at_least(Role.MERCHANT)
+    assert Role.ADMIN.at_least(Role.PLAYER)
+    assert Role.MERCHANT.at_least(Role.PLAYER)
+    assert Role.MERCHANT.at_least("player")
+    assert not Role.PLAYER.at_least(Role.ADMIN)
+    assert not Role.PLAYER.at_least("merchant")


### PR DESCRIPTION
## Summary
- add pytest configuration helpers that stub optional runtime dependencies so casino and model modules can be imported without Flask/SQLAlchemy
- cover CasinoManager configuration overrides, slot evaluation, and publish scheduling behavior with unit tests
- add a role hierarchy test to exercise Role.at_least semantics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d29c042aa08332a70b70c1eb53b402