### PR TITLE
Add games dropdown to header navigation

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -76,6 +76,56 @@ main {
   font-size: 0.95rem;
 }
 
+.nav-dropdown {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.nav-dropdown-toggle {
+  color: var(--text);
+  font-size: 0.95rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  user-select: none;
+}
+
+.nav-dropdown:hover .nav-dropdown-toggle,
+.nav-dropdown-toggle:hover {
+  color: var(--accent);
+}
+
+.nav-dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #0b141b;
+  border: 1px solid rgba(26, 255, 213, 0.2);
+  border-radius: 6px;
+  padding: 0.5rem 0;
+  min-width: 180px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  z-index: 10;
+}
+
+.nav-dropdown:hover .nav-dropdown-menu {
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-dropdown-menu a {
+  padding: 0.5rem 1rem;
+  white-space: nowrap;
+}
+
+.nav-dropdown-menu a:hover {
+  background: rgba(26, 255, 213, 0.1);
+  color: var(--accent);
+}
+
 .main-nav a:hover {
   color: var(--accent);
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,10 +18,15 @@
         {% if current_user.is_authenticated %}
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
           <a href="{{ url_for('main.inbox') }}">Inbox</a>
-          <a href="{{ url_for('main.single_player') }}">Solo Game</a>
-          <a href="{{ url_for('main.prisoners_dilemma') }}">Prisoner's Dilemma</a>
+          <div class="nav-dropdown">
+            <span class="nav-dropdown-toggle">Games ▾</span>
+            <div class="nav-dropdown-menu">
+              <a href="{{ url_for('main.single_player') }}">Solo Game</a>
+              <a href="{{ url_for('main.prisoners_dilemma') }}">Prisoner's Dilemma</a>
+              <a href="{{ url_for('main.casino') }}">Casino</a>
+            </div>
+          </div>
           <a href="{{ url_for('main.securities_hub') }}">Securities</a>
-          <a href="{{ url_for('main.casino') }}">Casino</a>
           {% if current_user.is_merchant %}
             <a href="{{ url_for('main.merchant_portal') }}">Merchant</a>
           {% endif %}


### PR DESCRIPTION
## Summary
- replace the separate game links in the header with a Games dropdown
- add styling for the dropdown menu so it matches the existing navigation aesthetics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2a2616c4c83328529ffe45c9f5e03