### PR TITLE
Add marketplace ordering system and merchant order queue

### DIFF
--- a/app/config/stock.toml
+++ b/app/config/stock.toml
@@ -1,0 +1,25 @@
+[[items]]
+key = "espresso"
+name = "Espresso"
+price = 4.50
+stock = 20
+enabled = true
+description = "A double shot of rocket fuel to keep you playing."
+image = "https://images.unsplash.com/photo-1511920170033-f8396924c348?w=400&auto=format&fit=crop&q=80"
+
+[[items]]
+key = "energy_bar"
+name = "Energy Bar"
+price = 3.00
+stock = 35
+enabled = true
+description = "Chocolate, caffeine, and mystery ingredients."
+image = "https://images.unsplash.com/photo-1589308078055-060c1c161b9d?w=400&auto=format&fit=crop&q=80"
+
+[[items]]
+key = "mystery_box"
+name = "Mystery Prize Box"
+price = 15.00
+stock = 5
+enabled = false
+description = "What's inside? Only the merchant knows."

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1663,3 +1663,205 @@ button.warning:hover {
 [data-reaction-game][data-outcome="error"] {
   box-shadow: 0 0 0 2px rgba(255, 79, 100, 0.45);
 }
+
+.marketplace .section-header,
+.merchant-portal .section-header,
+.orders-panel h2,
+.inventory-panel h2 {
+  margin-bottom: 1rem;
+}
+
+.product-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.product-card {
+  background: var(--panel);
+  border: 1px solid rgba(26, 255, 213, 0.2);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.product-card.selected,
+.product-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--accent);
+}
+
+.product-image {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+}
+
+.product-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.product-name {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.product-price {
+  font-weight: 700;
+  color: var(--accent);
+  margin: 0;
+}
+
+.product-description {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.product-stock {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.quantity-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.qty-input {
+  background: transparent;
+  border: 1px solid rgba(26, 255, 213, 0.3);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 0.4rem;
+}
+
+.checkout-bar {
+  position: sticky;
+  bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.checkout-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1.6rem;
+  background: var(--accent);
+  color: #001217;
+  border-color: var(--accent);
+  font-weight: 700;
+  border-radius: 999px;
+}
+
+.checkout-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.checkout-total {
+  font-size: 1.1rem;
+}
+
+.merchant-portal .orders-panel,
+.merchant-portal .inventory-panel {
+  margin-top: 2rem;
+}
+
+.order-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.order-card {
+  background: var(--panel);
+  border: 1px solid rgba(26, 255, 213, 0.25);
+  border-radius: 10px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-header h3 {
+  margin: 0;
+}
+
+.order-header p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.order-items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-items li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+.order-total {
+  font-weight: 700;
+  margin: 0;
+}
+
+.order-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.inventory-overview table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+
+.inventory-overview th,
+.inventory-overview td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(26, 255, 213, 0.1);
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-on {
+  background: rgba(26, 255, 213, 0.15);
+  color: var(--accent);
+}
+
+.status-off {
+  background: rgba(255, 79, 100, 0.15);
+  color: var(--danger);
+}
+
+.inventory-actions {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,6 +17,7 @@
         <a href="{{ url_for('main.index') }}">Home</a>
         {% if current_user.is_authenticated %}
           <a href="{{ url_for('main.dashboard') }}">Dashboard</a>
+          <a href="{{ url_for('main.marketplace') }}">Marketplace</a>
           <a href="{{ url_for('main.inbox') }}">Inbox</a>
           <div class="nav-dropdown">
             <span class="nav-dropdown-toggle">Games ▾</span>

--- a/app/templates/marketplace.html
+++ b/app/templates/marketplace.html
@@ -1,0 +1,93 @@
+{% extends 'base.html' %}
+{% block title %}Marketplace{% endblock %}
+{% block content %}
+<section class="marketplace">
+  <header class="section-header">
+    <h1>Marketplace</h1>
+    <p>Select your items and check out when you're ready.</p>
+  </header>
+  <form id="marketplace-form" method="post" class="marketplace-form">
+    <div class="product-grid">
+      {% for product in products %}
+        <article class="product-card" data-product-id="{{ product.id }}" data-price="{{ '%.2f'|format(product.price) }}">
+          {% if product.image_url %}
+            <img src="{{ product.image_url }}" alt="{{ product.name }}" class="product-image">
+          {% endif %}
+          <div class="product-body">
+            <h3 class="product-name">{{ product.name }}</h3>
+            <p class="product-price">{{ '%.2f'|format(product.price) }} credits</p>
+            {% if product.description %}
+              <p class="product-description">{{ product.description }}</p>
+            {% endif %}
+            <p class="product-stock">In stock: {{ product.stock }}</p>
+            <label class="quantity-control">
+              Quantity
+              <input type="number" class="qty-input" min="0" value="0" inputmode="numeric">
+            </label>
+          </div>
+        </article>
+      {% else %}
+        <p class="empty-state">Nothing is available right now. Check back later.</p>
+      {% endfor %}
+    </div>
+    <input type="hidden" name="cart" id="cart-data">
+    <div class="checkout-bar">
+      <button type="submit" id="checkout-button" class="checkout-button" disabled>
+        <span class="checkout-total" id="checkout-total">0.00</span>
+        <span class="checkout-count-wrapper">(<span id="checkout-count">0</span>)</span>
+        Check Out
+      </button>
+    </div>
+  </form>
+</section>
+{% endblock %}
+{% block scripts %}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('marketplace-form');
+    const cards = Array.from(document.querySelectorAll('.product-card'));
+    const cartField = document.getElementById('cart-data');
+    const totalSpan = document.getElementById('checkout-total');
+    const countSpan = document.getElementById('checkout-count');
+    const checkoutButton = document.getElementById('checkout-button');
+
+    function refreshCartSummary() {
+      let total = 0;
+      let count = 0;
+      const items = [];
+      for (const card of cards) {
+        const input = card.querySelector('.qty-input');
+        const quantity = parseInt(input.value, 10) || 0;
+        if (quantity > 0) {
+          const price = parseFloat(card.dataset.price);
+          total += price * quantity;
+          count += quantity;
+          items.push({ id: parseInt(card.dataset.productId, 10), quantity });
+          card.classList.add('selected');
+        } else {
+          card.classList.remove('selected');
+        }
+      }
+      totalSpan.textContent = total.toFixed(2);
+      countSpan.textContent = count;
+      cartField.value = JSON.stringify(items);
+      checkoutButton.disabled = items.length === 0;
+    }
+
+    cards.forEach((card) => {
+      const input = card.querySelector('.qty-input');
+      input.addEventListener('input', refreshCartSummary);
+      input.addEventListener('change', refreshCartSummary);
+    });
+
+    form.addEventListener('submit', (event) => {
+      refreshCartSummary();
+      if (!cartField.value || cartField.value === '[]') {
+        event.preventDefault();
+      }
+    });
+
+    refreshCartSummary();
+  });
+</script>
+{% endblock %}

--- a/app/templates/merchant.html
+++ b/app/templates/merchant.html
@@ -1,96 +1,138 @@
 {% extends 'base.html' %}
 {% block title %}Merchant Portal{% endblock %}
 {% block content %}
-<section class="grid">
-  <article class="panel">
-    <h2>Products</h2>
-    <ul class="list">
-      {% for product in products %}
-        <li>
-          <form method="post" class="inline-form">
-            <input type="hidden" name="product_id" value="{{ product.id }}">
-            <button class="link" name="action" value="select">{{ product.name }}</button>
-            <span class="amount">{{ '%.2f'|format(product.price) }}</span>
-            <span class="note">Stock: {{ product.stock }}</span>
-          </form>
-        </li>
-      {% else %}
-        <li>No products yet.</li>
-      {% endfor %}
-    </ul>
-  </article>
+<section class="merchant-portal">
+  <header class="section-header">
+    <h1>Merchant Portal</h1>
+    <p>Review orders and tune your marketplace inventory.</p>
+  </header>
 
-  <article class="panel">
-    <h2>Create product</h2>
-    {% if current_user.is_merchant %}
-      <form method="post" class="form">
-        <input type="hidden" name="action" value="add_product">
-        <label>Name<input type="text" name="name" required></label>
-        <label>Description<input type="text" name="description"></label>
-        <label>Price<input type="number" step="0.01" name="price" required></label>
-        <label>Stock<input type="number" name="stock" min="0" value="0"></label>
-        <button class="button" type="submit">Add product</button>
-      </form>
+  <section class="orders-panel">
+    <h2>Pending orders</h2>
+    {% if pending_orders %}
+      <div class="order-grid">
+        {% for order in pending_orders %}
+          <article class="order-card">
+            <header class="order-header">
+              <h3>Order #{{ order.id }}</h3>
+              <p>
+                {{ order.user.name }} · {{ order.created_at.strftime('%b %d, %Y %H:%M') }}
+              </p>
+            </header>
+            <ul class="order-items">
+              {% for item in order.items %}
+                <li>
+                  <span>{{ item.quantity }} × {{ item.product.name }}</span>
+                  <span>{{ '%.2f'|format(item.subtotal) }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+            <p class="order-total">Total: {{ '%.2f'|format(order.total_price) }} credits</p>
+            <div class="order-actions">
+              <form method="post">
+                <input type="hidden" name="order_id" value="{{ order.id }}">
+                <button class="button" name="action" value="complete_order">Mark complete</button>
+              </form>
+              <form method="post" onsubmit="return confirm('Cancel this order and issue a refund?');">
+                <input type="hidden" name="order_id" value="{{ order.id }}">
+                <button class="button danger" name="action" value="cancel_order">Cancel</button>
+              </form>
+            </div>
+          </article>
+        {% endfor %}
+      </div>
     {% else %}
-      <p>Only merchants can add products.</p>
+      <p class="empty-state">No orders are waiting right now.</p>
     {% endif %}
-  </article>
+  </section>
 
-  <article class="panel">
-    <h2>QR Checkout</h2>
-    {% if selected_product %}
-      <p>{{ selected_product.name }} — {{ '%.2f'|format(selected_product.price) }} credits</p>
-      <img class="qr" src="{{ qr_data_uri }}" alt="QR code for {{ selected_product.name }}">
-      {% if current_user.is_merchant %}
-        <a class="button" href="{{ url_for('main.process_sale', product_id=selected_product.id, buyer_id=current_user.id) }}">Process self-purchase</a>
-      {% endif %}
-    {% else %}
-      <p>Select a product to generate a QR code.</p>
-    {% endif %}
-  </article>
-
-  {% if current_user.is_merchant %}
-  <article class="panel">
-    <h2>Inventory adjustments</h2>
-    <form method="post" class="form">
-      <input type="hidden" name="action" value="update_price">
-      <label>Product
-        <select name="product_id" required>
+  <section class="inventory-panel">
+    <h2>Inventory</h2>
+    <div class="inventory-overview">
+      <table>
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>Status</th>
+            <th>Price</th>
+            <th>Stock</th>
+            <th>Base price</th>
+            <th>Base stock</th>
+          </tr>
+        </thead>
+        <tbody>
           {% for product in products %}
-            <option value="{{ product.id }}">{{ product.name }}</option>
+            <tr>
+              <td>{{ product.name }}</td>
+              <td>
+                {% if product.enabled %}
+                  <span class="status-pill status-on">Enabled</span>
+                {% else %}
+                  <span class="status-pill status-off">Disabled</span>
+                {% endif %}
+              </td>
+              <td>{{ '%.2f'|format(product.price) }}</td>
+              <td>{{ product.stock }}</td>
+              <td>{% if product.base_price is not none %}{{ '%.2f'|format(product.base_price) }}{% else %}—{% endif %}</td>
+              <td>{% if product.base_stock is not none %}{{ product.base_stock }}{% else %}—{% endif %}</td>
+            </tr>
           {% endfor %}
-        </select>
-      </label>
-      <label>New price<input type="number" step="0.01" name="price" required></label>
-      <button class="button" type="submit">Update price</button>
-    </form>
-    <form method="post" class="form">
-      <input type="hidden" name="action" value="update_stock">
-      <label>Product
-        <select name="product_id" required>
-          {% for product in products %}
-            <option value="{{ product.id }}">{{ product.name }}</option>
-          {% endfor %}
-        </select>
-      </label>
-      <label>New stock<input type="number" name="stock" min="0" required></label>
-      <button class="button" type="submit">Update stock</button>
-    </form>
-    <form method="post" class="form">
-      <input type="hidden" name="action" value="update_product_increase_pct">
-      <label>Product
-        <select name="product_id" required>
-          {% for product in products %}
-            <option value="{{ product.id }}">{{ product.name }}</option>
-          {% endfor %}
-        </select>
-      </label>
-      <label>Per-product price increase (%)
-        <input type="number" step="0.1" name="increase_pct" min="0">
-      </label>
-      <button class="button" type="submit">Save per-product sensitivity</button>
-    </form>
-  </article>
-  {% endif %}
+        </tbody>
+      </table>
+    </div>
+    <div class="inventory-actions">
+      <article class="panel">
+        <h3>Update price</h3>
+        <form method="post" class="form">
+          <input type="hidden" name="action" value="update_price">
+          <label>Product
+            <select name="product_id" required>
+              {% for product in products %}
+                <option value="{{ product.id }}">{{ product.name }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label>New price
+            <input type="number" name="price" step="0.01" min="0" required>
+          </label>
+          <button class="button" type="submit">Save price</button>
+        </form>
+      </article>
+      <article class="panel">
+        <h3>Adjust stock</h3>
+        <form method="post" class="form">
+          <input type="hidden" name="action" value="update_stock">
+          <label>Product
+            <select name="product_id" required>
+              {% for product in products %}
+                <option value="{{ product.id }}">{{ product.name }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label>New stock
+            <input type="number" name="stock" min="0" required>
+          </label>
+          <button class="button" type="submit">Save stock</button>
+        </form>
+      </article>
+      <article class="panel">
+        <h3>Price sensitivity</h3>
+        <form method="post" class="form">
+          <input type="hidden" name="action" value="update_product_increase_pct">
+          <label>Product
+            <select name="product_id" required>
+              {% for product in products %}
+                <option value="{{ product.id }}">{{ product.name }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label>Per-order increase (%)
+            <input type="number" step="0.1" min="0" name="increase_pct">
+          </label>
+          <button class="button" type="submit">Save sensitivity</button>
+        </form>
+      </article>
+    </div>
+  </section>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- read marketplace stock metadata from `stock.toml` into richer `Product` records and new merchant order tables
- add a player-facing marketplace with cart checkout, receipts, and dynamic pricing updates
- overhaul the merchant portal UI to manage pending orders, fulfillment, cancellations, and inventory controls with refreshed styling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d33997735083329214c811814b22bc