### PR TITLE
Implement player selector dropdown

### DIFF
--- a/app/static/player-selector.js
+++ b/app/static/player-selector.js
@@ -1,0 +1,195 @@
+(function () {
+  function normalizeDirectory(raw) {
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    return raw
+      .filter((entry) => entry && typeof entry.name === 'string' && typeof entry.handle === 'string')
+      .map((entry) => ({
+        name: entry.name,
+        handle: entry.handle,
+        nameLower: entry.name.toLowerCase(),
+        handleLower: entry.handle.toLowerCase(),
+      }))
+      .sort((a, b) => a.nameLower.localeCompare(b.nameLower));
+  }
+
+  function escapeHtml(value) {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function highlightMatches(text, query) {
+    if (!query) {
+      return escapeHtml(text);
+    }
+    const lowerText = text.toLowerCase();
+    const lowerQuery = query.toLowerCase();
+    let result = '';
+    let index = 0;
+    while (index < text.length) {
+      const matchIndex = lowerText.indexOf(lowerQuery, index);
+      if (matchIndex === -1) {
+        result += escapeHtml(text.slice(index));
+        break;
+      }
+      result += escapeHtml(text.slice(index, matchIndex));
+      result += '<strong>' + escapeHtml(text.slice(matchIndex, matchIndex + query.length)) + '</strong>';
+      index = matchIndex + query.length;
+    }
+    return result;
+  }
+
+  function buildOptionLabel(player, query) {
+    const safeName = highlightMatches(player.name, query);
+    const safeHandle = highlightMatches(player.handle, query);
+    return safeName + ' (' + safeHandle + ')';
+  }
+
+  function setupSelector(container, directory) {
+    if (container.dataset.playerSelectorReady === 'true') {
+      return;
+    }
+    const input = container.querySelector('input[type="text"], input[type="search"]');
+    if (!input) {
+      return;
+    }
+
+    container.dataset.playerSelectorReady = 'true';
+    container.classList.add('player-selector--enhanced');
+    input.setAttribute('autocomplete', 'off');
+
+    const dropdown = document.createElement('div');
+    dropdown.className = 'player-selector__dropdown';
+    const list = document.createElement('ul');
+    list.className = 'player-selector__list';
+    dropdown.appendChild(list);
+    container.appendChild(dropdown);
+
+    let results = [];
+    let activeIndex = -1;
+    let currentQuery = '';
+
+    function closeDropdown() {
+      dropdown.classList.remove('is-open');
+      activeIndex = -1;
+    }
+
+    function openDropdown() {
+      if (!results.length) {
+        closeDropdown();
+        return;
+      }
+      dropdown.classList.add('is-open');
+    }
+
+    function renderResults() {
+      list.innerHTML = '';
+      if (!results.length) {
+        closeDropdown();
+        return;
+      }
+      results.forEach((player, index) => {
+        const item = document.createElement('li');
+        item.className = 'player-selector__option';
+        if (index === activeIndex) {
+          item.classList.add('is-active');
+        }
+        item.innerHTML = buildOptionLabel(player, currentQuery);
+        item.dataset.handle = player.handle;
+        item.dataset.name = player.name;
+        item.addEventListener('mousedown', (event) => {
+          event.preventDefault();
+          selectOption(index);
+        });
+        list.appendChild(item);
+      });
+      openDropdown();
+    }
+
+    function selectOption(index) {
+      const choice = results[index];
+      if (!choice) {
+        return;
+      }
+      input.value = choice.handle;
+      input.dataset.selectedHandle = choice.handle;
+      input.dataset.selectedName = choice.name;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      closeDropdown();
+    }
+
+    function updateResults() {
+      currentQuery = input.value.trim();
+      input.dataset.selectedHandle = '';
+      input.dataset.selectedName = '';
+      if (!directory.length) {
+        results = [];
+        renderResults();
+        return;
+      }
+      if (!currentQuery) {
+        results = directory.slice(0, 5);
+      } else {
+        const normalizedQuery = currentQuery.toLowerCase();
+        results = directory
+          .filter(
+            (player) =>
+              player.nameLower.includes(normalizedQuery) ||
+              player.handleLower.includes(normalizedQuery)
+          )
+          .slice(0, 5);
+      }
+      activeIndex = results.length ? 0 : -1;
+      renderResults();
+    }
+
+    input.addEventListener('input', () => {
+      updateResults();
+    });
+
+    input.addEventListener('focus', () => {
+      updateResults();
+    });
+
+    input.addEventListener('blur', () => {
+      window.setTimeout(() => {
+        closeDropdown();
+      }, 120);
+    });
+
+    input.addEventListener('keydown', (event) => {
+      if (!results.length) {
+        return;
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        activeIndex = (activeIndex + 1) % results.length;
+        renderResults();
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        activeIndex = (activeIndex - 1 + results.length) % results.length;
+        renderResults();
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        const index = activeIndex >= 0 ? activeIndex : 0;
+        selectOption(index);
+      } else if (event.key === 'Escape') {
+        closeDropdown();
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const containers = Array.from(document.querySelectorAll('[data-player-selector]'));
+    if (!containers.length) {
+      return;
+    }
+    const directory = normalizeDirectory(window.PLAYER_DIRECTORY || []);
+    containers.forEach((container) => setupSelector(container, directory));
+  });
+})();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1156,6 +1156,52 @@ button.warning:hover {
   margin-top: 0.4rem;
 }
 
+.player-selector {
+  position: relative;
+}
+
+.player-selector__dropdown {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  display: none;
+  background: #0f161d;
+  border: 1px solid rgba(26, 255, 213, 0.2);
+  border-radius: 6px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  z-index: 25;
+}
+
+.player-selector__dropdown.is-open {
+  display: block;
+}
+
+.player-selector__list {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.player-selector__option {
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--text);
+}
+
+.player-selector__option strong {
+  color: var(--accent);
+}
+
+.player-selector__option:hover,
+.player-selector__option.is-active {
+  background: rgba(26, 255, 213, 0.12);
+}
+
 .form textarea {
   width: 100%;
   padding: 0.5rem;

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -119,7 +119,9 @@
           <input type="radio" name="audience" value="handle">
           Specific handle
         </label>
-        <input type="text" name="target_handle" placeholder="player-handle" />
+        <div class="player-selector" data-player-selector>
+          <input type="text" name="target_handle" placeholder="player-handle" />
+        </div>
       </fieldset>
       <button class="button" type="submit">Send alert</button>
     </form>
@@ -242,4 +244,11 @@ async function refreshTransactions() {
 }
 setInterval(refreshTransactions, 5000);
 </script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    window.PLAYER_DIRECTORY = {{ player_directory|tojson }};
+  </script>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -59,6 +59,7 @@
   <footer class="app-footer">
     Landrum et al. · {{ now.year }}
   </footer>
+  <script defer src="{{ url_for('static', filename='player-selector.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -20,8 +20,10 @@
     <form class="form" method="post" action="{{ url_for('main.handle_transfer') }}">
       <input type="hidden" name="action" value="send" />
       <label>
-        Recipient handle
-        <input type="text" name="handle" value="{{ target_handle }}" placeholder="friend" required />
+        Recipient
+        <div class="player-selector" data-player-selector>
+          <input type="text" name="handle" value="{{ target_handle }}" placeholder="friend" required />
+        </div>
       </label>
       <label>
         Amount
@@ -41,8 +43,10 @@
     <form class="form" method="post" action="{{ url_for('main.handle_transfer') }}">
       <input type="hidden" name="action" value="request" />
       <label>
-        From handle
-        <input type="text" name="handle" value="{{ target_handle }}" placeholder="merchant" required />
+        From
+        <div class="player-selector" data-player-selector>
+          <input type="text" name="handle" value="{{ target_handle }}" placeholder="merchant" required />
+        </div>
       </label>
       <label>
         Amount
@@ -135,4 +139,11 @@
     </article>
   {% endif %}
 </section>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    window.PLAYER_DIRECTORY = {{ player_directory|tojson }};
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a helper to build the player directory and expose it to the dashboard and admin views
- introduce a reusable player selector script and styling that filters and highlights matches
- replace handle text inputs with the new selector on credit transfers and admin alerts

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_nyc_now' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68d3f6279d7883329cd0ec2c8ebcdc89