### PR TITLE
Implement configurable economy system

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -98,6 +98,7 @@ def create_app(test_config=None):
     from .securities import init_market
     from .casino import init_casino
     from .games import init_games
+    from .economy import init_economy
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
@@ -106,6 +107,7 @@ def create_app(test_config=None):
     init_market(app)
     init_casino(app)
     init_games(app)
+    init_economy(app)
 
     @app.context_processor
     def inject_now():

--- a/app/casino.py
+++ b/app/casino.py
@@ -17,7 +17,27 @@ except ModuleNotFoundError:  # pragma: no cover - defensive fallback
 from flask import current_app, has_app_context
 from sqlalchemy.orm import joinedload
 
-from . import db, get_nyc_now
+try:
+    from . import db, get_nyc_now
+except ImportError:  # pragma: no cover - support standalone imports during testing
+    from types import SimpleNamespace
+
+    def _noop(*_args, **_kwargs):
+        return None
+
+    db = SimpleNamespace(
+        create_all=_noop,
+        session=SimpleNamespace(
+            add=_noop,
+            commit=_noop,
+            rollback=_noop,
+            remove=_noop,
+            flush=_noop,
+        ),
+    )
+
+    def get_nyc_now():  # type: ignore[misc]
+        return datetime.utcnow()
 from .models import AppSetting, Security, SecurityHolding, Transaction, User
 
 

--- a/app/config/economy.toml
+++ b/app/config/economy.toml
@@ -1,0 +1,15 @@
+[pricing]
+purchase_impact = 0.0125
+cross_cooling = 0.0015
+default_liquidity = 100.0
+min_price = 0.1
+max_price = 10000.0
+
+[payouts]
+payout_impact = 0.008
+cross_recovery = 0.001
+default_liquidity = 8.0
+min_multiplier = 0.05
+max_multiplier = 5.0
+baseline_multiplier = 1.0
+tracked_games = ["single_player", "prisoners"]

--- a/app/economy.py
+++ b/app/economy.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import copy
+import math
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from threading import Lock
+from typing import Dict, Iterable, Optional
+
+import tomllib
+
+from . import db
+
+
+_CURRENT_GAME_CONTEXT: ContextVar[Optional[str]] = ContextVar(
+    "economy_game_context", default=None
+)
+
+
+def _default_config() -> dict:
+    return {
+        "pricing": {
+            "purchase_impact": 0.0125,
+            "cross_cooling": 0.0015,
+            "default_liquidity": 100.0,
+            "min_price": 0.1,
+            "max_price": 10_000.0,
+            "liquidity_overrides": {},
+        },
+        "payouts": {
+            "payout_impact": 0.008,
+            "cross_recovery": 0.001,
+            "default_liquidity": 8.0,
+            "min_multiplier": 0.05,
+            "max_multiplier": 5.0,
+            "baseline_multiplier": 1.0,
+            "liquidity_overrides": {},
+            "tracked_games": ["single_player", "prisoners"],
+        },
+    }
+
+
+def _ensure_directory(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _render_config(config: dict) -> str:
+    pricing = config.get("pricing", {})
+    payouts = config.get("payouts", {})
+    lines: list[str] = []
+    lines.append("[pricing]")
+    lines.append(f"purchase_impact = {pricing.get('purchase_impact', 0.0)}")
+    lines.append(f"cross_cooling = {pricing.get('cross_cooling', 0.0)}")
+    lines.append(f"default_liquidity = {pricing.get('default_liquidity', 0.0)}")
+    lines.append(f"min_price = {pricing.get('min_price', 0.0)}")
+    lines.append(f"max_price = {pricing.get('max_price', 0.0)}")
+    liquidity_overrides = pricing.get("liquidity_overrides", {}) or {}
+    if liquidity_overrides:
+        lines.append("")
+        lines.append("[pricing.liquidity_overrides]")
+        for key, value in liquidity_overrides.items():
+            lines.append(f"{key} = {float(value)}")
+
+    lines.append("")
+    lines.append("[payouts]")
+    lines.append(f"payout_impact = {payouts.get('payout_impact', 0.0)}")
+    lines.append(f"cross_recovery = {payouts.get('cross_recovery', 0.0)}")
+    lines.append(f"default_liquidity = {payouts.get('default_liquidity', 0.0)}")
+    lines.append(f"min_multiplier = {payouts.get('min_multiplier', 0.0)}")
+    lines.append(f"max_multiplier = {payouts.get('max_multiplier', 0.0)}")
+    lines.append(f"baseline_multiplier = {payouts.get('baseline_multiplier', 1.0)}")
+    tracked = payouts.get("tracked_games", []) or []
+    tracked_repr = ", ".join(f'"{game}"' for game in tracked)
+    lines.append(f"tracked_games = [{tracked_repr}]")
+    payout_overrides = payouts.get("liquidity_overrides", {}) or {}
+    if payout_overrides:
+        lines.append("")
+        lines.append("[payouts.liquidity_overrides]")
+        for key, value in payout_overrides.items():
+            lines.append(f"{key} = {float(value)}")
+    lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def _inverse_ratio(value: float, liquidity: float) -> float:
+    if liquidity <= 0:
+        return 0.0
+    denominator = max(abs(value), 1e-6)
+    return liquidity / denominator
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    if value < minimum:
+        return minimum
+    if value > maximum:
+        return maximum
+    return value
+
+
+@dataclass
+class EconomyManager:
+    config_path: Path
+    _config: dict = field(default_factory=_default_config)
+    _lock: Lock = field(default_factory=Lock)
+    _config_mtime: Optional[float] = None
+
+    def _load_config_locked(self) -> None:
+        try:
+            stat = self.config_path.stat()
+        except FileNotFoundError:
+            _ensure_directory(self.config_path)
+            self._write_config_locked()
+            return
+
+        if self._config_mtime is not None and stat.st_mtime <= self._config_mtime:
+            return
+
+        try:
+            with self.config_path.open("rb") as fh:
+                data = tomllib.load(fh)
+        except tomllib.TOMLDecodeError:
+            # Keep existing config if new version fails to parse
+            return
+
+        config = _default_config()
+        pricing = config["pricing"]
+        payouts = config["payouts"]
+
+        raw_pricing = data.get("pricing", {}) or {}
+        raw_payouts = data.get("payouts", {}) or {}
+
+        pricing.update(
+            {
+                "purchase_impact": float(raw_pricing.get("purchase_impact", pricing["purchase_impact"])),
+                "cross_cooling": float(raw_pricing.get("cross_cooling", pricing["cross_cooling"])),
+                "default_liquidity": float(
+                    raw_pricing.get("default_liquidity", pricing["default_liquidity"])
+                ),
+                "min_price": float(raw_pricing.get("min_price", pricing["min_price"])),
+                "max_price": float(raw_pricing.get("max_price", pricing["max_price"])),
+            }
+        )
+        liquidity_overrides = raw_pricing.get("liquidity_overrides", {}) or {}
+        pricing["liquidity_overrides"] = {
+            str(key): float(value)
+            for key, value in liquidity_overrides.items()
+            if _is_number(value)
+        }
+
+        payouts.update(
+            {
+                "payout_impact": float(raw_payouts.get("payout_impact", payouts["payout_impact"])),
+                "cross_recovery": float(
+                    raw_payouts.get("cross_recovery", payouts["cross_recovery"])
+                ),
+                "default_liquidity": float(
+                    raw_payouts.get("default_liquidity", payouts["default_liquidity"])
+                ),
+                "min_multiplier": float(
+                    raw_payouts.get("min_multiplier", payouts["min_multiplier"])
+                ),
+                "max_multiplier": float(
+                    raw_payouts.get("max_multiplier", payouts["max_multiplier"])
+                ),
+                "baseline_multiplier": float(
+                    raw_payouts.get("baseline_multiplier", payouts["baseline_multiplier"])
+                ),
+            }
+        )
+        payout_overrides = raw_payouts.get("liquidity_overrides", {}) or {}
+        payouts["liquidity_overrides"] = {
+            str(key): float(value)
+            for key, value in payout_overrides.items()
+            if _is_number(value)
+        }
+        tracked_games = raw_payouts.get("tracked_games", payouts.get("tracked_games", [])) or []
+        payouts["tracked_games"] = [str(entry) for entry in tracked_games]
+
+        self._config = config
+        self._config_mtime = stat.st_mtime
+
+    def _write_config_locked(self) -> None:
+        _ensure_directory(self.config_path)
+        content = _render_config(self._config)
+        self.config_path.write_text(content, encoding="utf-8")
+        try:
+            self._config_mtime = self.config_path.stat().st_mtime
+        except FileNotFoundError:
+            self._config_mtime = None
+
+    def get_config(self) -> dict:
+        with self._lock:
+            self._load_config_locked()
+            return copy.deepcopy(self._config)
+
+    def update_config(self, *, pricing: dict | None = None, payouts: dict | None = None) -> None:
+        with self._lock:
+            self._load_config_locked()
+            if pricing:
+                self._config["pricing"].update(pricing)
+            if payouts:
+                self._config["payouts"].update(payouts)
+            self._write_config_locked()
+
+    # Pricing adjustments -------------------------------------------------
+    def apply_purchase(self, product, quantity: int) -> None:
+        if quantity <= 0:
+            return
+        from .models import PriceHistory, Product
+
+        with self._lock:
+            self._load_config_locked()
+            pricing = self._config["pricing"]
+
+        liquidity = self._product_liquidity(product, pricing)
+        base_price = max(product.price or 0.0, 0.0)
+        ratio_inverse = _inverse_ratio(base_price or 1.0, liquidity)
+        increase = pricing["purchase_impact"] * ratio_inverse
+        increase = min(increase, 5.0)
+        factor = (1.0 + increase) ** quantity
+        new_price = _clamp(base_price * factor, pricing["min_price"], pricing["max_price"])
+        self._update_product_price(product, new_price)
+
+        cross = pricing.get("cross_cooling", 0.0)
+        if cross <= 0:
+            return
+
+        others: Iterable[Product] = (
+            Product.query.filter(Product.id != product.id, Product.enabled.is_(True)).all()
+        )
+        for other in others:
+            other_liq = self._product_liquidity(other, pricing)
+            other_ratio_inverse = _inverse_ratio(other.price or 1.0, other_liq)
+            decrease = min(cross * quantity * other_ratio_inverse, 0.95)
+            factor = max(0.0, 1.0 - decrease)
+            new_value = _clamp(
+                (other.price or 0.0) * factor,
+                pricing["min_price"],
+                pricing["max_price"],
+            )
+            self._update_product_price(other, new_value)
+
+    def quote_purchase_prices(self, product, quantity: int) -> list[float]:
+        if quantity <= 0:
+            return []
+        with self._lock:
+            self._load_config_locked()
+            pricing = self._config["pricing"]
+        liquidity = self._product_liquidity(product, pricing)
+        base_price = max(product.price or 0.0, 0.0)
+        ratio_inverse = _inverse_ratio(base_price or 1.0, liquidity)
+        increase = min(pricing["purchase_impact"] * ratio_inverse, 5.0)
+        step_factor = 1.0 + increase
+        min_price = pricing["min_price"]
+        max_price = pricing["max_price"]
+        current = _clamp(base_price, min_price, max_price)
+        prices: list[float] = []
+        for _ in range(quantity):
+            prices.append(round(current, 4))
+            current = _clamp(current * step_factor, min_price, max_price)
+        return prices
+
+    def _product_liquidity(self, product, pricing: dict) -> float:
+        overrides = pricing.get("liquidity_overrides", {}) or {}
+        key_id = str(getattr(product, "id", ""))
+        key_name = getattr(product, "name", "")
+        if key_id in overrides:
+            return max(float(overrides[key_id]), 1e-6)
+        lowered = key_name.lower() if isinstance(key_name, str) else ""
+        if lowered and lowered in overrides:
+            return max(float(overrides[lowered]), 1e-6)
+        base_stock = getattr(product, "base_stock", None)
+        if base_stock is not None and base_stock > 0:
+            return float(base_stock)
+        return float(pricing.get("default_liquidity", 1.0))
+
+    def _update_product_price(self, product, new_price: float) -> None:
+        if not math.isfinite(new_price):
+            return
+        current = product.price or 0.0
+        if abs(current - new_price) < 1e-4:
+            return
+        from .models import PriceHistory
+
+        product.price = new_price
+        product.updated_at = datetime.utcnow()
+        history = PriceHistory(product=product, price=new_price)
+        db.session.add(history)
+
+    # Game payout adjustments ---------------------------------------------
+    def activate_game_context(self, key: str) -> float:
+        key = str(key)
+        _CURRENT_GAME_CONTEXT.set(key)
+        with self._lock:
+            self._load_config_locked()
+            self._ensure_tracked_game_locked(key)
+            payouts = self._config["payouts"]
+        return self.get_game_multiplier(key, payouts)
+
+    def current_game_context(self) -> Optional[str]:
+        return _CURRENT_GAME_CONTEXT.get()
+
+    def get_game_multiplier(self, key: str, payouts_cfg: Optional[dict] = None) -> float:
+        from .models import AppSetting
+
+        if payouts_cfg is None:
+            with self._lock:
+                self._load_config_locked()
+                payouts_cfg = self._config["payouts"]
+        stored = AppSetting.get(f"economy:game:{key}:multiplier", None)
+        if stored is None:
+            return float(payouts_cfg.get("baseline_multiplier", 1.0))
+        try:
+            value = float(stored)
+        except (TypeError, ValueError):
+            return float(payouts_cfg.get("baseline_multiplier", 1.0))
+        return _clamp(
+            value,
+            float(payouts_cfg.get("min_multiplier", 0.0)),
+            float(payouts_cfg.get("max_multiplier", 10.0)),
+        )
+
+    def _set_game_multiplier(self, key: str, value: float, payouts_cfg: dict) -> None:
+        from .models import AppSetting
+
+        value = _clamp(
+            float(value),
+            float(payouts_cfg.get("min_multiplier", 0.0)),
+            float(payouts_cfg.get("max_multiplier", 10.0)),
+        )
+        current = self.get_game_multiplier(key, payouts_cfg)
+        if abs(current - value) < 1e-4:
+            return
+        AppSetting.set(f"economy:game:{key}:multiplier", f"{value:.6f}")
+
+    def record_game_payout(self, amount: float, game_key: Optional[str] = None) -> None:
+        if amount <= 0:
+            return
+        with self._lock:
+            self._load_config_locked()
+            payouts = self._config["payouts"]
+        key = str(game_key or self.current_game_context() or "")
+        if not key:
+            return
+        self._ensure_tracked_game(key, payouts)
+        liquidity = self._game_liquidity(key, payouts)
+        inverse = _inverse_ratio(amount, liquidity)
+        primary_decrease = min(payouts["payout_impact"] * inverse, 0.95)
+        current = self.get_game_multiplier(key, payouts)
+        primary_multiplier = current * max(0.0, 1.0 - primary_decrease)
+        self._set_game_multiplier(key, primary_multiplier, payouts)
+
+        cross = payouts.get("cross_recovery", 0.0)
+        if cross <= 0:
+            return
+
+        for other_key in self._tracked_games(payouts):
+            if other_key == key:
+                continue
+            other_multiplier = self.get_game_multiplier(other_key, payouts)
+            other_liq = self._game_liquidity(other_key, payouts)
+            other_inverse = _inverse_ratio(other_multiplier or 1.0, other_liq)
+            increase = min(cross * other_inverse, 0.5)
+            adjusted = other_multiplier * (1.0 + increase)
+            self._set_game_multiplier(other_key, adjusted, payouts)
+
+    def get_game_multipliers(self) -> Dict[str, float]:
+        with self._lock:
+            self._load_config_locked()
+            payouts = self._config["payouts"]
+            keys = list(self._tracked_games(payouts))
+        return {key: self.get_game_multiplier(key, payouts) for key in keys}
+
+    def _ensure_tracked_game_locked(self, key: str) -> None:
+        payouts = self._config["payouts"]
+        if key not in payouts.get("tracked_games", []):
+            payouts.setdefault("tracked_games", []).append(key)
+            self._write_config_locked()
+
+    def _ensure_tracked_game(self, key: str, payouts: dict) -> None:
+        with self._lock:
+            self._load_config_locked()
+            if key not in self._config["payouts"].get("tracked_games", []):
+                self._config["payouts"].setdefault("tracked_games", []).append(key)
+                self._write_config_locked()
+
+    def _tracked_games(self, payouts: dict) -> Iterable[str]:
+        return payouts.get("tracked_games", []) or []
+
+    def _game_liquidity(self, key: str, payouts: dict) -> float:
+        overrides = payouts.get("liquidity_overrides", {}) or {}
+        if key in overrides:
+            return max(float(overrides[key]), 1e-6)
+        return float(payouts.get("default_liquidity", 1.0))
+
+
+def _is_number(value) -> bool:
+    try:
+        float(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+_economy_manager: Optional[EconomyManager] = None
+
+
+def init_economy(app) -> None:
+    global _economy_manager
+    if _economy_manager is not None:
+        return
+    path_value = app.config.get(
+        "ECONOMY_CONFIG_PATH",
+        Path(app.root_path) / "config" / "economy.toml",
+    )
+    config_path = Path(path_value)
+    _economy_manager = EconomyManager(config_path=config_path)
+    # Ensure initial config exists
+    _economy_manager.get_config()
+
+
+def get_economy_manager() -> Optional[EconomyManager]:
+    return _economy_manager
+

--- a/app/models.py
+++ b/app/models.py
@@ -261,6 +261,7 @@ class MerchantOrder(db.Model):
     charge_transaction_id = db.Column(db.Integer, db.ForeignKey("transaction.id"), nullable=True)
     payout_transaction_id = db.Column(db.Integer, db.ForeignKey("transaction.id"), nullable=True)
     refund_transaction_id = db.Column(db.Integer, db.ForeignKey("transaction.id"), nullable=True)
+    economy_adjustments = db.Column(db.JSON, nullable=True)
 
     user = db.relationship("User", foreign_keys=[user_id], lazy=True)
     charge_transaction = db.relationship("Transaction", foreign_keys=[charge_transaction_id], lazy=True)

--- a/app/routes.py
+++ b/app/routes.py
@@ -33,6 +33,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
 from . import db, get_nyc_now, utc_to_nyc, nyc_to_utc, format_nyc_datetime
+from .economy import get_economy_manager
 from .models import (
     FutureHolding,
     FutureListing,
@@ -262,29 +263,27 @@ def record_transaction(user, amount, description, counterparty=None, type_="game
         type=type_,
     )
     db.session.add(txn)
-    # If this is a positive game reward (player earned credits), reduce future game rewards via per-game multiplier
-    if type_ == "game" and amount > 0:
-        try:
-            game_key = AppSetting.get("current_game_context", None)
-            if game_key:
-                dec_pct = float(AppSetting.get(f"game:{game_key}:decrease_pct", AppSetting.get("game_reward_decrease_pct", "5.0") or "5.0"))
-                current_mult = float(AppSetting.get(f"game:{game_key}:multiplier", "1.0") or "1.0")
-                new_mult = max(0.0, current_mult * (1.0 - dec_pct / 100.0))
-                AppSetting.set(f"game:{game_key}:multiplier", f"{new_mult}")
-        except Exception:
-            pass
+    if type_ in {"game", "casino"} and amount > 0:
+        manager = get_economy_manager()
+        if manager:
+            try:
+                manager.record_game_payout(amount)
+            except Exception:
+                current_app.logger.exception("Failed to register game payout in economy manager")
     if commit:
         db.session.commit()
     return txn
 
 
 def _activate_game_context(game_key: str) -> float:
-    AppSetting.set("current_game_context", game_key)
+    manager = get_economy_manager()
+    if not manager:
+        return 1.0
     try:
-        multiplier = float(AppSetting.get(f"game:{game_key}:multiplier", "1.0") or "1.0")
+        return manager.activate_game_context(game_key)
     except Exception:
-        multiplier = 1.0
-    return multiplier if multiplier >= 0 else 0.0
+        current_app.logger.exception("Failed to activate game context for %s", game_key)
+        return 1.0
 
 
 def _create_alert(creator, recipients: List[User], message: str, *, title: str | None = None, category: str = "message", payload: dict | None = None, vote: ShareholderVote | None = None):
@@ -999,12 +998,7 @@ def trade_future():
 @login_required
 def single_player():
     base_reward = 5.0
-    # Use per-game multiplier keyed by 'single_player'
-    AppSetting.set("current_game_context", "single_player")
-    try:
-        mult = float(AppSetting.get("game:single_player:multiplier", "1.0") or "1.0")
-    except Exception:
-        mult = 1.0
+    mult = _activate_game_context("single_player")
     reward = round(base_reward * mult, 2)
     if request.method == "POST":
         record_transaction(current_user, reward, "Won the solo clicker game")
@@ -2257,7 +2251,7 @@ def telestrations_upvote(entry_id: int):
 @login_required
 def casino():
     manager = get_casino_manager()
-    AppSetting.set("current_game_context", "casino")
+    _activate_game_context("casino")
     return render_template(
         "casino.html",
         slots=manager.get_slots(),
@@ -2268,7 +2262,7 @@ def casino():
 @bp.route("/casino/slot", methods=["POST"])
 @login_required
 def play_slot():
-    AppSetting.set("current_game_context", "casino")
+    _activate_game_context("casino")
     wants_json = request.is_json or request.accept_mimetypes.best == "application/json"
 
     if request.is_json:
@@ -2402,7 +2396,7 @@ def _format_line_label(win: SlotLineWin) -> str:
 @bp.route("/casino/blackjack", methods=["POST"])
 @login_required
 def play_blackjack():
-    AppSetting.set("current_game_context", "casino")
+    _activate_game_context("casino")
     wager = request.form.get("wager", type=float)
     if wager is None:
         flash("Enter a wager for blackjack.", "error")
@@ -2551,12 +2545,7 @@ def submit_choice(match, user, choice):
 
 def resolve_match(match):
     payoff = PAYOFFS[(match.player1_choice, match.player2_choice)]
-    # Use per-game multiplier keyed by 'prisoners'
-    AppSetting.set("current_game_context", "prisoners")
-    try:
-        mult = float(AppSetting.get("game:prisoners:multiplier", "1.0") or "1.0")
-    except Exception:
-        mult = 1.0
+    mult = _activate_game_context("prisoners")
     # Scale only positive rewards by multiplier; penalties remain unchanged
     p1_amount = payoff[0] * mult if payoff[0] > 0 else payoff[0]
     p2_amount = payoff[1] * mult if payoff[1] > 0 else payoff[1]
@@ -2579,6 +2568,7 @@ def marketplace():
     products = sync_products_from_stock()
     product_map = {product.id: product for product in products}
     visible_products = [product for product in products if product.enabled]
+    economy_manager = get_economy_manager()
 
     if request.method == "POST":
         cart_raw = request.form.get("cart", "[]")
@@ -2622,13 +2612,10 @@ def marketplace():
         total_cost = 0.0
         pricing_breakdown: dict[int, tuple[list[float], float]] = {}
         for product, quantity in selections:
-            inc_pct = get_price_increase_pct(product)
-            current_price = product.price
-            line_prices: list[float] = []
-            for _ in range(quantity):
-                line_prices.append(current_price)
-                if inc_pct > 0:
-                    current_price = current_price * (1 + inc_pct / 100.0)
+            if economy_manager:
+                line_prices = economy_manager.quote_purchase_prices(product, quantity)
+            else:
+                line_prices = [product.price for _ in range(quantity)]
             subtotal = round(sum(line_prices), 2)
             pricing_breakdown[product.id] = (line_prices, subtotal)
             total_cost += subtotal
@@ -2659,7 +2646,7 @@ def marketplace():
                 pricing_snapshot=[round(price, 4) for price in line_prices],
             )
             db.session.add(item)
-            apply_dynamic_price_increase(product, quantity, commit=False)
+            apply_economy_purchase_adjustments(product, quantity, commit=False)
 
         charge_txn = record_transaction(
             current_user,
@@ -2770,7 +2757,7 @@ def merchant_portal():
             return redirect(url_for("main.merchant_portal"))
 
         product_id = request.form.get("product_id")
-        if action in {"update_price", "update_stock", "update_product_increase_pct"} and not product_id:
+        if action in {"update_price", "update_stock", "update_product_liquidity"} and not product_id:
             flash("Select a product first.", "error")
             return redirect(url_for("main.merchant_portal"))
 
@@ -2803,15 +2790,25 @@ def merchant_portal():
                 flash("Stock updated.", "success")
             return redirect(url_for("main.merchant_portal"))
 
-        if action == "update_product_increase_pct" and product_id:
+        if action == "update_product_liquidity" and product_id:
+            manager = get_economy_manager()
+            if not manager:
+                flash("Economy manager unavailable.", "error")
+                return redirect(url_for("main.merchant_portal"))
             try:
-                pct = float(request.form.get("increase_pct", ""))
-                if pct < 0:
-                    raise ValueError("Percentage must be non-negative")
-                AppSetting.set(f"product:{int(product_id)}:increase_pct", str(pct))
-                flash("Per-product sensitivity saved.", "success")
+                raw_liquidity = request.form.get("liquidity", "")
+                liquidity_value = float(raw_liquidity) if raw_liquidity != "" else None
+                config = manager.get_config()
+                overrides = dict(config.get("pricing", {}).get("liquidity_overrides", {}))
+                key = str(int(product_id))
+                if liquidity_value is None or liquidity_value <= 0:
+                    overrides.pop(key, None)
+                else:
+                    overrides[key] = max(0.0, liquidity_value)
+                manager.update_config(pricing={"liquidity_overrides": overrides})
+                flash("Liquidity override saved.", "success")
             except Exception as exc:
-                flash(f"Failed to save per-product sensitivity: {exc}", "error")
+                flash(f"Failed to save liquidity override: {exc}", "error")
             return redirect(url_for("main.merchant_portal"))
 
         return redirect(url_for("main.merchant_portal"))
@@ -2833,29 +2830,16 @@ def update_price(product, new_price, *, commit: bool = True, announce: bool = Tr
         flash("Price updated.", "success")
 
 
-def get_price_increase_pct(product: Product) -> float:
-    try:
-        return float(
-            AppSetting.get(
-                f"product:{product.id}:increase_pct",
-                AppSetting.get("price_increase_pct", "5.0") or "5.0",
-            )
-        )
-    except Exception:
-        return 0.0
-
-
-def apply_dynamic_price_increase(product: Product, quantity: int, *, commit: bool = True):
-    if quantity <= 0:
+def apply_economy_purchase_adjustments(product: Product, quantity: int, *, commit: bool = True):
+    manager = get_economy_manager()
+    if not manager or quantity <= 0:
         if commit:
             db.session.commit()
         return
-    inc_pct = get_price_increase_pct(product)
-    for _ in range(quantity):
-        if inc_pct <= 0:
-            break
-        new_price = product.price * (1 + inc_pct / 100.0)
-        update_price(product, new_price, commit=False, announce=False)
+    try:
+        manager.apply_purchase(product, quantity)
+    except Exception:
+        current_app.logger.exception("Failed to apply purchase adjustment via economy manager")
     if commit:
         db.session.commit()
 
@@ -2924,7 +2908,7 @@ def process_sale(product_id):
             commit=False,
         )
         try:
-            apply_dynamic_price_increase(product, 1, commit=False)
+            apply_economy_purchase_adjustments(product, 1, commit=False)
             db.session.commit()
             flash("Sale completed.", "success")
         except Exception as exc:
@@ -2962,12 +2946,18 @@ def admin_dashboard():
         ShareholderVote.query.order_by(ShareholderVote.created_at.desc()).limit(5).all()
     )
     stats = build_price_stats(products)
-    default_increase = AppSetting.get("price_increase_pct", "5.0")
-    # Defaults for per-game settings
-    sp_dec = AppSetting.get("game:single_player:decrease_pct", AppSetting.get("game_reward_decrease_pct", "5.0"))
-    sp_mult = AppSetting.get("game:single_player:multiplier", "1.0")
-    pd_dec = AppSetting.get("game:prisoners:decrease_pct", AppSetting.get("game_reward_decrease_pct", "5.0"))
-    pd_mult = AppSetting.get("game:prisoners:multiplier", "1.0")
+    economy_manager = get_economy_manager()
+    pricing_cfg: dict[str, float] = {}
+    payouts_cfg: dict[str, float] = {}
+    game_multipliers: dict[str, float] = {}
+    if economy_manager:
+        try:
+            config = economy_manager.get_config()
+            pricing_cfg = config.get("pricing", {}) or {}
+            payouts_cfg = config.get("payouts", {}) or {}
+            game_multipliers = economy_manager.get_game_multipliers()
+        except Exception:
+            current_app.logger.exception("Failed to load economy configuration")
     casino_manager = get_casino_manager()
     casino_status = casino_manager.get_status()
 
@@ -2990,11 +2980,9 @@ def admin_dashboard():
         stats=stats,
         users=users,
         securities=securities,
-        price_increase_pct=default_increase,
-        sp_dec=sp_dec,
-        sp_mult=sp_mult,
-        pd_dec=pd_dec,
-        pd_mult=pd_mult,
+        pricing_cfg=pricing_cfg,
+        payouts_cfg=payouts_cfg,
+        game_multipliers=game_multipliers,
         casino_status=casino_status,
         alerts=recent_alerts,
         open_votes=open_votes,
@@ -3330,16 +3318,44 @@ def build_price_stats(products):
 def update_pricing_settings():
     if not current_user.is_admin:
         abort(403)
+    manager = get_economy_manager()
+    if not manager:
+        flash("Economy manager unavailable.", "error")
+        return redirect(url_for("main.admin_dashboard"))
     try:
-        inc = float(request.form.get("price_increase_pct", "5"))
-        sp_dec = float(request.form.get("sp_dec", "5"))
-        pd_dec = float(request.form.get("pd_dec", "5"))
-        if inc < 0 or sp_dec < 0 or pd_dec < 0:
-            raise ValueError("Sensitivities must be non-negative")
-        AppSetting.set("price_increase_pct", str(inc))
-        AppSetting.set("game:single_player:decrease_pct", str(sp_dec))
-        AppSetting.set("game:prisoners:decrease_pct", str(pd_dec))
-        flash("Sensitivities updated.", "success")
+        purchase_impact = max(0.0, float(request.form.get("purchase_impact", "0")))
+        cross_cooling = max(0.0, float(request.form.get("cross_cooling", "0")))
+        pricing_liquidity = max(0.0, float(request.form.get("pricing_liquidity", "0")))
+        min_price = max(0.0, float(request.form.get("min_price", "0")))
+        max_price = max(0.0, float(request.form.get("max_price", "0")))
+        payout_impact = max(0.0, float(request.form.get("payout_impact", "0")))
+        cross_recovery = max(0.0, float(request.form.get("cross_recovery", "0")))
+        payout_liquidity = max(0.0, float(request.form.get("payout_liquidity", "0")))
+        min_multiplier = max(0.0, float(request.form.get("min_multiplier", "0")))
+        max_multiplier = max(0.0, float(request.form.get("max_multiplier", "0")))
+        baseline_multiplier = max(0.0, float(request.form.get("baseline_multiplier", "1")))
+        if max_price and min_price and max_price < min_price:
+            raise ValueError("Maximum price must be greater than or equal to minimum price")
+        if max_multiplier and min_multiplier and max_multiplier < min_multiplier:
+            raise ValueError("Maximum multiplier must be greater than or equal to minimum multiplier")
+        manager.update_config(
+            pricing={
+                "purchase_impact": purchase_impact,
+                "cross_cooling": cross_cooling,
+                "default_liquidity": pricing_liquidity,
+                "min_price": min_price,
+                "max_price": max_price,
+            },
+            payouts={
+                "payout_impact": payout_impact,
+                "cross_recovery": cross_recovery,
+                "default_liquidity": payout_liquidity,
+                "min_multiplier": min_multiplier,
+                "max_multiplier": max_multiplier,
+                "baseline_multiplier": baseline_multiplier,
+            },
+        )
+        flash("Economy settings updated.", "success")
     except Exception as exc:
         flash(f"Failed to update settings: {exc}", "error")
     return redirect(url_for("main.admin_dashboard"))

--- a/app/routes.py
+++ b/app/routes.py
@@ -8,7 +8,7 @@ import secrets
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional, Sequence, Set, Tuple
+from typing import Iterable, List, Optional, Sequence, Set, Tuple
 
 import tomllib
 
@@ -2651,6 +2651,8 @@ def marketplace():
         db.session.add(order)
         db.session.flush()
 
+        aggregated_adjustments: dict[int, dict[str, float]] = {}
+
         for product, quantity in selections:
             product.stock = max(0, (product.stock or 0) - quantity)
             line_prices, subtotal = pricing_breakdown.get(product.id, ([], 0.0))
@@ -2664,7 +2666,30 @@ def marketplace():
                 pricing_snapshot=[round(price, 4) for price in line_prices],
             )
             db.session.add(item)
-            apply_economy_purchase_adjustments(product, quantity, commit=False)
+            changes = apply_economy_purchase_adjustments(product, quantity, commit=False)
+            for change in changes or []:
+                try:
+                    product_id = int(change.get("product_id"))
+                except (TypeError, ValueError):
+                    continue
+                if product_id <= 0:
+                    continue
+                record = aggregated_adjustments.get(product_id)
+                before = change.get("before")
+                after = change.get("after")
+                try:
+                    before_val = float(before)
+                    after_val = float(after)
+                except (TypeError, ValueError):
+                    continue
+                if record:
+                    record["after"] = after_val
+                else:
+                    aggregated_adjustments[product_id] = {
+                        "product_id": product_id,
+                        "before": before_val,
+                        "after": after_val,
+                    }
 
         charge_txn = record_transaction(
             current_user,
@@ -2685,6 +2710,16 @@ def marketplace():
             category="order_receipt",
             payload={"order_id": order.id, "status": "pending", "total": total_cost},
         )
+
+        if aggregated_adjustments:
+            order.economy_adjustments = [
+                {
+                    "product_id": entry["product_id"],
+                    "before": entry["before"],
+                    "after": entry["after"],
+                }
+                for entry in aggregated_adjustments.values()
+            ]
 
         db.session.commit()
         flash("Order placed! We'll let you know when it's ready.", "success")
@@ -2757,6 +2792,9 @@ def merchant_portal():
                 for item in order.items:
                     item.product.stock = (item.product.stock or 0) + item.quantity
                     item.product.updated_at = datetime.utcnow()
+                if order.economy_adjustments:
+                    revert_economy_adjustments(order.economy_adjustments, commit=False)
+                    order.economy_adjustments = None
                 refund = record_transaction(
                     order.user,
                     order.total_price,
@@ -2860,11 +2898,27 @@ def apply_economy_purchase_adjustments(product: Product, quantity: int, *, commi
     if not manager or quantity <= 0:
         if commit:
             db.session.commit()
-        return
+        return []
     try:
-        manager.apply_purchase(product, quantity)
+        adjustments = manager.apply_purchase(product, quantity)
     except Exception:
         current_app.logger.exception("Failed to apply purchase adjustment via economy manager")
+        adjustments = []
+    if commit:
+        db.session.commit()
+    return adjustments
+
+
+def revert_economy_adjustments(adjustments: Iterable[dict[str, float]], *, commit: bool = True):
+    manager = get_economy_manager()
+    if not manager or not adjustments:
+        if commit:
+            db.session.commit()
+        return
+    try:
+        manager.reverse_adjustments(adjustments)
+    except Exception:
+        current_app.logger.exception("Failed to reverse economy adjustments")
     if commit:
         db.session.commit()
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -2725,9 +2725,16 @@ def merchant_portal():
             if action == "complete_order":
                 order.status = "completed"
                 order.completed_at = datetime.utcnow()
+                payout_amount = order.total_price
+                if order.charge_transaction is not None:
+                    payout_amount = abs(order.charge_transaction.amount or 0.0)
+                    if payout_amount <= 0:
+                        payout_amount = order.total_price
+                    if order.charge_transaction.counterparty is None:
+                        order.charge_transaction.counterparty = current_user
                 payout = record_transaction(
                     current_user,
-                    order.total_price,
+                    payout_amount,
                     f"Fulfilled order #{order.id}",
                     counterparty=order.user,
                     type_="sale",

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -55,30 +55,62 @@
   </article>
 
   <article class="panel">
-    <h2>Pricing & Reward Sensitivities</h2>
+    <h2>Economy Controls</h2>
     <form method="post" action="{{ url_for('main.update_pricing_settings') }}" class="form">
-      <label>Increase on purchase (%)
-        <input type="number" name="price_increase_pct" step="0.1" min="0" value="{{ price_increase_pct or '5.0' }}">
-      </label>
-      <div class="grid">
-        <div>
-          <h3>Single Player</h3>
-          <label>Decrease rewards after payout (%)
-            <input type="number" name="sp_dec" step="0.1" min="0" value="{{ sp_dec or '5.0' }}">
+      <fieldset class="fieldset">
+        <legend>Marketplace pricing</legend>
+        <label>Purchase impact factor
+          <input type="number" name="purchase_impact" step="0.0001" min="0" value="{{ pricing_cfg.get('purchase_impact', 0.0) }}">
+        </label>
+        <label>Cross-product cooling factor
+          <input type="number" name="cross_cooling" step="0.0001" min="0" value="{{ pricing_cfg.get('cross_cooling', 0.0) }}">
+        </label>
+        <label>Default product liquidity
+          <input type="number" name="pricing_liquidity" step="0.1" min="0" value="{{ pricing_cfg.get('default_liquidity', 0.0) }}">
+        </label>
+        <div class="grid">
+          <label>Minimum price
+            <input type="number" name="min_price" step="0.01" min="0" value="{{ pricing_cfg.get('min_price', 0.0) }}">
           </label>
-          <p class="note">Current multiplier: {{ sp_mult or '1.0' }}</p>
-        </div>
-        <div>
-          <h3>Prisoner's Dilemma</h3>
-          <label>Decrease rewards after payout (%)
-            <input type="number" name="pd_dec" step="0.1" min="0" value="{{ pd_dec or '5.0' }}">
+          <label>Maximum price
+            <input type="number" name="max_price" step="0.01" min="0" value="{{ pricing_cfg.get('max_price', 0.0) }}">
           </label>
-          <p class="note">Current multiplier: {{ pd_mult or '1.0' }}</p>
         </div>
-      </div>
-      <button class="button" type="submit">Save</button>
+      </fieldset>
+      <fieldset class="fieldset">
+        <legend>Game payouts</legend>
+        <label>Payout impact factor
+          <input type="number" name="payout_impact" step="0.0001" min="0" value="{{ payouts_cfg.get('payout_impact', 0.0) }}">
+        </label>
+        <label>Cross-game recovery factor
+          <input type="number" name="cross_recovery" step="0.0001" min="0" value="{{ payouts_cfg.get('cross_recovery', 0.0) }}">
+        </label>
+        <label>Default payout liquidity
+          <input type="number" name="payout_liquidity" step="0.1" min="0" value="{{ payouts_cfg.get('default_liquidity', 0.0) }}">
+        </label>
+        <div class="grid">
+          <label>Minimum multiplier
+            <input type="number" name="min_multiplier" step="0.01" min="0" value="{{ payouts_cfg.get('min_multiplier', 0.0) }}">
+          </label>
+          <label>Maximum multiplier
+            <input type="number" name="max_multiplier" step="0.01" min="0" value="{{ payouts_cfg.get('max_multiplier', 0.0) }}">
+          </label>
+        </div>
+        <label>Baseline multiplier
+          <input type="number" name="baseline_multiplier" step="0.01" min="0" value="{{ payouts_cfg.get('baseline_multiplier', 1.0) }}">
+        </label>
+      </fieldset>
+      <button class="button" type="submit">Save economy settings</button>
     </form>
-    <p class="note">Purchase increases item price; game wins reduce future rewards via per-game multipliers.</p>
+    <p class="note">Purchases and payouts automatically rebalance according to these parameters.</p>
+    {% if game_multipliers %}
+      <h3>Live payout multipliers</h3>
+      <ul class="list">
+        {% for key, value in game_multipliers.items() %}
+          <li><strong>{{ key }}</strong>: {{ '%.3f'|format(value) }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </article>
 
   <article class="panel">
@@ -207,7 +239,7 @@
   <article class="panel">
     <h2>Per-Product Sensitivities</h2>
     <form method="post" action="{{ url_for('main.merchant_portal') }}" class="form">
-      <input type="hidden" name="action" value="update_product_increase_pct">
+      <input type="hidden" name="action" value="update_product_liquidity">
       <label>Product
         <select name="product_id" required>
           {% for product in products %}
@@ -215,8 +247,8 @@
           {% endfor %}
         </select>
       </label>
-      <label>Per-product price increase (%)
-        <input type="number" step="0.1" name="increase_pct" min="0">
+      <label>Liquidity override
+        <input type="number" step="0.1" name="liquidity" min="0">
       </label>
       <button class="button" type="submit">Save</button>
     </form>

--- a/app/templates/marketplace.html
+++ b/app/templates/marketplace.html
@@ -9,13 +9,23 @@
   <form id="marketplace-form" method="post" class="marketplace-form">
     <div class="product-grid">
       {% for product in products %}
-        <article class="product-card" data-product-id="{{ product.id }}" data-price="{{ '%.2f'|format(product.price) }}">
+        {% set quote = pricing_context.get(product.id) %}
+        {% set base_price = quote.first_price if quote else product.price %}
+        {% set step_factor = quote.step_factor if quote else 1.0 %}
+        {% set min_price = quote.min_price if quote else 0.0 %}
+        {% set max_price = quote.max_price if quote else base_price %}
+        <article class="product-card"
+                 data-product-id="{{ product.id }}"
+                 data-base-price="{{ '%.4f'|format(base_price) }}"
+                 data-step-factor="{{ '%.12f'|format(step_factor) }}"
+                 data-min-price="{{ '%.4f'|format(min_price) }}"
+                 data-max-price="{{ '%.4f'|format(max_price) }}">
           {% if product.image_url %}
             <img src="{{ product.image_url }}" alt="{{ product.name }}" class="product-image">
           {% endif %}
           <div class="product-body">
             <h3 class="product-name">{{ product.name }}</h3>
-            <p class="product-price">{{ '%.2f'|format(product.price) }} credits</p>
+            <p class="product-price">{{ '%.2f'|format(base_price) }} credits</p>
             {% if product.description %}
               <p class="product-description">{{ product.description }}</p>
             {% endif %}
@@ -51,6 +61,58 @@
     const countSpan = document.getElementById('checkout-count');
     const checkoutButton = document.getElementById('checkout-button');
 
+    function clamp(value, min, max) {
+      if (!Number.isFinite(value)) {
+        return min;
+      }
+      if (!Number.isFinite(min)) {
+        min = value;
+      }
+      if (!Number.isFinite(max)) {
+        max = min;
+      }
+      if (max < min) {
+        max = min;
+      }
+      if (value < min) {
+        return min;
+      }
+      if (value > max) {
+        return max;
+      }
+      return value;
+    }
+
+    function computeLinePricing(basePrice, stepFactor, minPrice, maxPrice, quantity) {
+      if (!Number.isFinite(basePrice)) {
+        basePrice = 0;
+      }
+      if (!Number.isFinite(stepFactor) || stepFactor <= 0) {
+        stepFactor = 1;
+      }
+      if (!Number.isFinite(minPrice)) {
+        minPrice = 0;
+      }
+      if (!Number.isFinite(maxPrice)) {
+        maxPrice = minPrice;
+      }
+      if (maxPrice < minPrice) {
+        maxPrice = minPrice;
+      }
+      let subtotal = 0;
+      let current = clamp(basePrice, minPrice, maxPrice);
+      for (let i = 0; i < quantity; i += 1) {
+        subtotal += current;
+        const multiplied = current * stepFactor;
+        let nextPrice = clamp(multiplied, minPrice, maxPrice);
+        if (!Number.isFinite(nextPrice)) {
+          nextPrice = current;
+        }
+        current = nextPrice;
+      }
+      return { subtotal, nextPrice: current };
+    }
+
     function refreshCartSummary() {
       let total = 0;
       let count = 0;
@@ -58,9 +120,17 @@
       for (const card of cards) {
         const input = card.querySelector('.qty-input');
         const quantity = parseInt(input.value, 10) || 0;
+        const priceLabel = card.querySelector('.product-price');
+        const basePrice = parseFloat(card.dataset.basePrice);
+        const stepFactor = parseFloat(card.dataset.stepFactor);
+        const minPrice = parseFloat(card.dataset.minPrice);
+        const maxPrice = parseFloat(card.dataset.maxPrice);
+        const { subtotal, nextPrice } = computeLinePricing(basePrice, stepFactor, minPrice, maxPrice, quantity);
+        if (priceLabel) {
+          priceLabel.textContent = `${nextPrice.toFixed(2)} credits`;
+        }
         if (quantity > 0) {
-          const price = parseFloat(card.dataset.price);
-          total += price * quantity;
+          total += subtotal;
           count += quantity;
           items.push({ id: parseInt(card.dataset.productId, 10), quantity });
           card.classList.add('selected');


### PR DESCRIPTION
## Summary
- add an economy manager that centralizes price and payout tuning using economy.toml
- wire purchases, game payouts, and admin controls into the new manager with liquidity overrides
- update admin UI and casino module fallbacks to support the new configuration flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3fc81742083329fb2ca8b3e720941